### PR TITLE
Timo/associated types

### DIFF
--- a/sparse-traits/src/lib.rs
+++ b/sparse-traits/src/lib.rs
@@ -4,6 +4,7 @@ pub mod operator;
 pub mod types;
 pub mod linear_space;
 pub mod index_set;
+pub mod views;
 
 pub use operator::*;
 pub use types::*;

--- a/sparse-traits/src/linear_space.rs
+++ b/sparse-traits/src/linear_space.rs
@@ -1,7 +1,10 @@
 //! Stubs for linear spaces.
+use crate::{views::VectorTypedView, GeneralScalar};
 
 /// Definition of a linear space
 pub trait LinearSpace {
+
+    fn create_vector(&self) -> Box<&dyn Vector>;
 
 }
 

--- a/sparse-traits/src/linear_space.rs
+++ b/sparse-traits/src/linear_space.rs
@@ -1,14 +1,13 @@
 //! Stubs for linear spaces.
-use crate::{views::VectorTypedView, GeneralScalar};
+use crate::Scalar;
 
 /// Definition of a linear space
 pub trait LinearSpace {
-
-    fn create_vector(&self) -> Box<&dyn Vector>;
-
+    type Item: Scalar;
+    fn create_vector(&self) -> Box<&dyn Vector<Item=Self::Item>>;
 }
 
 /// A vector is an element of a linear space.
 pub trait Vector {
-
+    type Item: Scalar;
 }

--- a/sparse-traits/src/operator.rs
+++ b/sparse-traits/src/operator.rs
@@ -33,6 +33,10 @@ pub trait OperatorBase: Debug {
     fn has_matvec(&self) -> bool {
         self.as_matvec().is_some()
     }
+
+    // Check if a given vector allows type conversion to the native type
+    // of the operator.
+    //fn is_compatible(&self, vec: &dyn Vector);
 }
 
 /// Matrix vector product $Ax$.

--- a/sparse-traits/src/types.rs
+++ b/sparse-traits/src/types.rs
@@ -1,7 +1,31 @@
 //! Basic types
 
-use cauchy::Scalar;
+use num::traits::{One, Zero};
+use std::cmp::PartialEq;
+use std::ops::{Add, Mul, Sub};
 
-pub trait GeneralScalar: cauchy::Scalar {}
+pub trait GeneralScalar:
+    Add<Self, Output = Self>
+    + Sub<Self, Output = Self>
+    + Mul<Self, Output = Self>
+    + PartialEq
+    + Zero
+    + One
+    + Sized
+{
+}
 
-impl<T: Scalar> GeneralScalar for T {}
+impl<
+        T: Add<T, Output = T>
+            + Sub<T, Output = T>
+            + Mul<T, Output = T>
+            + Sized
+            + PartialEq
+            + Zero
+            + One
+            + Sized,
+    > GeneralScalar for T
+{
+}
+
+pub type IndexType = usize;

--- a/sparse-traits/src/types.rs
+++ b/sparse-traits/src/types.rs
@@ -4,7 +4,7 @@ use num::traits::{One, Zero};
 use std::cmp::PartialEq;
 use std::ops::{Add, Mul, Sub};
 
-pub trait GeneralScalar:
+pub trait Scalar:
     Add<Self, Output = Self>
     + Sub<Self, Output = Self>
     + Mul<Self, Output = Self>
@@ -24,7 +24,7 @@ impl<
             + Zero
             + One
             + Sized,
-    > GeneralScalar for T
+    > Scalar for T
 {
 }
 

--- a/sparse-traits/src/types.rs
+++ b/sparse-traits/src/types.rs
@@ -2,7 +2,7 @@
 
 use num::traits::{One, Zero};
 use std::cmp::PartialEq;
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Mul, Sub, Div};
 
 pub trait Scalar:
     Add<Self, Output = Self>
@@ -19,6 +19,7 @@ impl<
         T: Add<T, Output = T>
             + Sub<T, Output = T>
             + Mul<T, Output = T>
+            + Div<T, Output = T>
             + Sized
             + PartialEq
             + Zero

--- a/sparse-traits/src/views.rs
+++ b/sparse-traits/src/views.rs
@@ -2,7 +2,7 @@
 pub use crate::types::*;
 
 pub trait VectorTypedView<'a> {
-    type Item: GeneralScalar;
+    type Item: Scalar;
 
     // We would like to define the iterator just by a trait.
     // But this requires generic associated types (GATs), which luckily

--- a/sparse-traits/src/views.rs
+++ b/sparse-traits/src/views.rs
@@ -1,0 +1,30 @@
+//! Definition of view traits.
+pub use crate::types::*;
+
+pub trait VectorTypedView<'a> {
+    type Item: GeneralScalar;
+
+    // We would like to define the iterator just by a trait.
+    // But this requires generic associated types (GATs), which luckily
+    // become stable in Rust 1.65 scheduled for 3 November. We
+    // can then use
+    //
+    // type I<T: GeneralScalar>: std::iter::Iterator<Item = T>;
+    //
+
+    // Put the usual accessor methods here.
+
+    /// Reference to a single element.
+    fn get(&self, index: IndexType) -> Option<&'a Self::Item>;
+
+    /// Mutable reference to a single element.
+    fn get_mut(&mut self, index: IndexType) -> Option<&'a mut Self::Item>;
+
+    // With GATs we can then write
+
+    // /// Iterator
+    // fn iter(&self) -> I<&'a Self::Item>;
+
+    // /// Mutable iterator
+    // fn iter_mut(&mut self) -> I<'a mut Self::Item>;
+}


### PR DESCRIPTION
1.)  Implemented associated types for operators and vectors.

`OperatorBase` now has two associated types `In` and `Out` for the scalar input and output type. Vector has an associted scalar type called `Item`. The trait methods have been adapted accordingly. This gives every object a native type. We could then implement adapters on top to allow conversion between different representations.

2.) I have made a proposal for a scalar trait type. It is a subset of the `Num` trait from the `num` crate. It does not require string conversion and only needs addition, multiplication, subtraction, and division. It has no remainder operation as this might not always make sense (consider the scalar type for example itself to be a dense matrix). Not sure yet if this is best but would be good to have a definition that allows arbitrary fields as scalar type.

3.) I updated the `test_mult_sketchy` test to succeed when the matvec panics.