### PR TITLE
Vector implementation

### DIFF
--- a/sparse-core/Cargo.toml
+++ b/sparse-core/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 sparse-traits = {path = "../sparse-traits"}
 mpi = "0.6.*"
+num = "0.4"

--- a/sparse-core/Cargo.toml
+++ b/sparse-core/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2021"
 sparse-traits = {path = "../sparse-traits"}
 mpi = "0.6.*"
 num = "0.4"
+
+[dev-dependencies]
+cauchy = "0.4"
+float_eq = { version = "1", features = ["num"] }

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -1,25 +1,26 @@
-
 //! Example file for creating vectors.
 
-use mpi::topology::SystemCommunicator;
 use sparse_core::distributed::index_layout::DistributedIndexLayout;
-use sparse_traits::indexable_vector::{IndexableVector, Inner, SquareSum, NormInf};
-use sparse_core::distributed::DistributedIndexableVector;
+use sparse_core::distributed::indexable_space::DistributedIndexableVectorSpace;
+use sparse_traits::indexable_vector::{IndexableVector, Inner, NormInf, SquareSum};
+use sparse_traits::Element;
+use sparse_traits::LinearSpace;
 
 fn main() {
-
     let universe = mpi::initialize().unwrap();
     let world = universe.world();
 
-    let index_layout = DistributedIndexLayout::new((0, 4), &world);
+    let index_layout = DistributedIndexLayout::new((0, 100), &world);
 
-    let mut vec = DistributedIndexableVector::<'_, f64, SystemCommunicator>::new(&index_layout);
-    if let Some(val) = vec.get_mut(0) {
+    let space = DistributedIndexableVectorSpace::<'_, f64, _>::new(&index_layout);
+
+    let mut vec = space.create_element();
+
+    if let Some(val) = vec.view_mut().get_mut(0) {
         *val = 0.5;
     }
 
-
-    println!("Inner: {}", vec.inner(&vec).unwrap());
-    println!("Square sum: {}", vec.square_sum());
-    println!("Inf norm: {}", vec.norm_inf());
+    println!("Inner: {}", vec.view().inner(&vec.view()).unwrap());
+    println!("Square sum: {}", vec.view().square_sum());
+    println!("Inf norm: {}", vec.view().norm_inf());
 }

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -2,7 +2,7 @@
 
 use sparse_core::distributed::index_layout::DistributedIndexLayout;
 use sparse_core::distributed::indexable_space::DistributedIndexableVectorSpace;
-use sparse_traits::indexable_vector::{IndexableVector, Inner, NormInf, SquareSum};
+use sparse_traits::linalg::{IndexableVector, Inner, NormInf, SquareSum};
 use sparse_traits::Element;
 use sparse_traits::LinearSpace;
 

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -6,6 +6,7 @@ use sparse_core::distributed::indexable_space::DistributedIndexableVectorSpace;
 use sparse_traits::linalg::{Inner, NormInf, AbsSquareSum};
 use sparse_traits::Element;
 use sparse_traits::LinearSpace;
+use sparse_traits::IndexLayout;
 
 fn main() {
     let universe = mpi::initialize().unwrap();
@@ -23,7 +24,9 @@ fn main() {
         *val = 0.5;
     }
 
-    println!("Inner: {}", vec.view().inner(&vec.view()).unwrap());
-    println!("Square sum: {}", vec.view().abs_square_sum());
-    println!("Inf norm: {}", vec.view().norm_inf());
+    println!("Range: {:#?}", index_layout.local_range());
+
+    // println!("Inner: {}", vec.view().inner(&vec.view()).unwrap());
+    // println!("Square sum: {}", vec.view().abs_square_sum());
+    // println!("Inf norm: {}", vec.view().norm_inf());
 }

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -1,18 +1,23 @@
 //! Example file for creating vectors.
 
+use mpi::traits::*;
 use sparse_core::distributed::index_layout::DistributedIndexLayout;
-use sparse_traits::linalg::*;
 use sparse_core::distributed::indexable_space::DistributedIndexableVectorSpace;
-use sparse_traits::linalg::{Inner, NormInf, AbsSquareSum};
+use sparse_core::local::index_layout::LocalIndexLayout;
+use sparse_core::local::indexable_vector::LocalIndexableVector;
+use sparse_traits::IndexLayout;
+use sparse_traits::linalg::*;
 use sparse_traits::Element;
 use sparse_traits::LinearSpace;
-use sparse_traits::IndexLayout;
 
 fn main() {
     let universe = mpi::initialize().unwrap();
     let world = universe.world();
+    let rank = world.rank();
 
-    let index_layout = DistributedIndexLayout::new((0, 100), &world);
+    let n = 100;
+
+    let index_layout = DistributedIndexLayout::new((0, n), &world);
 
     let space = DistributedIndexableVectorSpace::<'_, f64, _>::new(&index_layout);
 
@@ -20,13 +25,45 @@ fn main() {
 
     let vec_impl = vec.view_mut();
 
-    if let Some(val) = vec_impl.view_mut().unwrap().get_mut(0) {
-        *val = 0.5;
+    // if let Some(val) = vec_impl.view_mut().unwrap().get_mut(0) {
+    //     *val = 0.5;
+    // }
+
+    let mut local_vec: LocalIndexableVector<'_, f64>;
+
+    if rank == 0 {
+        let local_layout = LocalIndexLayout::new((0, n));
+
+        local_vec = LocalIndexableVector::<'_, f64>::new(&local_layout);
+        let mut view = local_vec.view_mut().unwrap();
+
+        for index in 0..n {
+            *view.get_mut(index).unwrap() = index as f64;
+        }
+
+        println!("Local inf norm: {}", local_vec.norm_inf());
+
+        let _ = vec_impl.fill_from_root(&Some(local_vec));
+
+        println!("Root: {}", vec_impl.view().unwrap().data().get(49).unwrap());
+        println!("Global dofs {}", vec_impl.index_layout().number_of_global_indices());
+        println!("Dofs at root {:#?}", vec_impl.index_layout().index_range(1));
+    } else {
+        let _ = vec_impl.fill_from_root(&None);
+        println!("Proc 1: {}", vec_impl.view().unwrap().data().get(49).unwrap());
+        println!("Dofs at root {:#?}", vec_impl.index_layout().index_range(1));
     }
+    println!("Inner: {}", vec.view().inner(&vec.view()).unwrap());
+    println!("Inf norm: {}", vec.view().norm_inf());
 
-    println!("Range: {:#?}", index_layout.local_range());
-
-    // println!("Inner: {}", vec.view().inner(&vec.view()).unwrap());
-    // println!("Square sum: {}", vec.view().abs_square_sum());
-    // println!("Inf norm: {}", vec.view().norm_inf());
+    if world.rank() == 0 {
+        // for index in 0..(world.size() as usize) {
+        //     println!(
+        //         "count: {}, displacement: {}",
+        //         index_layout.counts()[index],
+        //         index_layout.displacements()[index]
+        //     );
+        // }
+        // println!("Square sum: {}", vec.view().abs_square_sum());
+    }
 }

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -21,6 +21,6 @@ fn main() {
     }
 
     println!("Inner: {}", vec.view().inner(&vec.view()).unwrap());
-    println!("Square sum: {}", vec.view().square_sum());
+    println!("Square sum: {}", vec.view().abs_square_sum());
     println!("Inf norm: {}", vec.view().norm_inf());
 }

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -2,7 +2,7 @@
 
 use sparse_core::distributed::index_layout::DistributedIndexLayout;
 use sparse_core::distributed::indexable_space::DistributedIndexableVectorSpace;
-use sparse_traits::linalg::{IndexableVector, Inner, NormInf, SquareSum};
+use sparse_traits::linalg::{IndexableVector, Inner, NormInf, AbsSquareSum};
 use sparse_traits::Element;
 use sparse_traits::LinearSpace;
 

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -35,7 +35,7 @@ fn main() {
             *view.get_mut(index).unwrap() = index as f64;
         }
 
-        println!("Local inf norm: {}", local_vec.norm_inf());
+        println!("Local inf norm: {}", local_vec.norm_infty());
         println!("Local inner: {}", local_vec.inner(&local_vec).unwrap());
 
         let _ = vec_impl.fill_from_root(&Some(local_vec));
@@ -44,7 +44,7 @@ fn main() {
     }
 
     let inner = vec.view().inner(&vec.view()).unwrap();
-    let inf_norm = vec.view().norm_inf();
+    let inf_norm = vec.view().norm_infty();
 
     if rank == 0 {
         println!("Inner: {}", &inner);

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -1,0 +1,25 @@
+
+//! Example file for creating vectors.
+
+use mpi::topology::SystemCommunicator;
+use sparse_core::distributed::index_layout::DistributedIndexLayout;
+use sparse_traits::indexable_vector::{IndexableVector, Inner, SquareSum, NormInf};
+use sparse_core::distributed::DistributedIndexableVector;
+
+fn main() {
+
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    let index_layout = DistributedIndexLayout::new((0, 4), &world);
+
+    let mut vec = DistributedIndexableVector::<'_, f64, SystemCommunicator>::new(&index_layout);
+    if let Some(val) = vec.get_mut(0) {
+        *val = 0.5;
+    }
+
+
+    println!("Inner: {}", vec.inner(&vec).unwrap());
+    println!("Square sum: {}", vec.square_sum());
+    println!("Inf norm: {}", vec.norm_inf());
+}

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -5,7 +5,6 @@ use sparse_core::distributed::index_layout::DistributedIndexLayout;
 use sparse_core::distributed::indexable_space::DistributedIndexableVectorSpace;
 use sparse_core::local::index_layout::LocalIndexLayout;
 use sparse_core::local::indexable_vector::LocalIndexableVector;
-use sparse_traits::IndexLayout;
 use sparse_traits::linalg::*;
 use sparse_traits::Element;
 use sparse_traits::LinearSpace;
@@ -17,17 +16,12 @@ fn main() {
 
     let n = 100;
 
+    // We first create an index layout.
     let index_layout = DistributedIndexLayout::new((0, n), &world);
-
     let space = DistributedIndexableVectorSpace::<'_, f64, _>::new(&index_layout);
-
     let mut vec = space.create_element();
 
     let vec_impl = vec.view_mut();
-
-    // if let Some(val) = vec_impl.view_mut().unwrap().get_mut(0) {
-    //     *val = 0.5;
-    // }
 
     let mut local_vec: LocalIndexableVector<'_, f64>;
 
@@ -42,28 +36,18 @@ fn main() {
         }
 
         println!("Local inf norm: {}", local_vec.norm_inf());
+        println!("Local inner: {}", local_vec.inner(&local_vec).unwrap());
 
         let _ = vec_impl.fill_from_root(&Some(local_vec));
-
-        println!("Root: {}", vec_impl.view().unwrap().data().get(49).unwrap());
-        println!("Global dofs {}", vec_impl.index_layout().number_of_global_indices());
-        println!("Dofs at root {:#?}", vec_impl.index_layout().index_range(1));
     } else {
         let _ = vec_impl.fill_from_root(&None);
-        println!("Proc 1: {}", vec_impl.view().unwrap().data().get(49).unwrap());
-        println!("Dofs at root {:#?}", vec_impl.index_layout().index_range(1));
     }
-    println!("Inner: {}", vec.view().inner(&vec.view()).unwrap());
-    println!("Inf norm: {}", vec.view().norm_inf());
 
-    if world.rank() == 0 {
-        // for index in 0..(world.size() as usize) {
-        //     println!(
-        //         "count: {}, displacement: {}",
-        //         index_layout.counts()[index],
-        //         index_layout.displacements()[index]
-        //     );
-        // }
-        // println!("Square sum: {}", vec.view().abs_square_sum());
+    let inner = vec.view().inner(&vec.view()).unwrap();
+    let inf_norm = vec.view().norm_inf();
+
+    if rank == 0 {
+        println!("Inner: {}", &inner);
+        println!("Inf norm: {}", &inf_norm);
     }
 }

--- a/sparse-core/examples/mpi_vector.rs
+++ b/sparse-core/examples/mpi_vector.rs
@@ -1,8 +1,9 @@
 //! Example file for creating vectors.
 
 use sparse_core::distributed::index_layout::DistributedIndexLayout;
+use sparse_traits::linalg::*;
 use sparse_core::distributed::indexable_space::DistributedIndexableVectorSpace;
-use sparse_traits::linalg::{IndexableVector, Inner, NormInf, AbsSquareSum};
+use sparse_traits::linalg::{Inner, NormInf, AbsSquareSum};
 use sparse_traits::Element;
 use sparse_traits::LinearSpace;
 
@@ -16,7 +17,9 @@ fn main() {
 
     let mut vec = space.create_element();
 
-    if let Some(val) = vec.view_mut().get_mut(0) {
+    let vec_impl = vec.view_mut();
+
+    if let Some(val) = vec_impl.view_mut().unwrap().get_mut(0) {
         *val = 0.5;
     }
 

--- a/sparse-core/examples/vector.rs
+++ b/sparse-core/examples/vector.rs
@@ -3,7 +3,7 @@
 use sparse_core::local::indexable_space::LocalIndexableVectorSpace;
 use sparse_traits::Element;
 use sparse_traits::NormedSpace;
-use sparse_traits::linalg::IndexableVector;
+use sparse_traits::linalg::*;
 use sparse_traits::LinearSpace;
 use sparse_traits::linalg::Norm2;
 
@@ -11,9 +11,9 @@ fn main() {
     let space = LocalIndexableVectorSpace::<f64>::new(10);
     let mut vec = space.create_element();
 
-    *vec.view_mut().get_mut(0).unwrap() = 2.0;
+    *vec.view_mut().view_mut().unwrap().get_mut(0).unwrap() = 2.0;
 
-    let n = vec.view().len();
+    let n = vec.view().view().unwrap().len();
     println!("The dimension of the vector is {}", n);
     println!("The norm of the vector is {}", vec.view().norm_2());
 

--- a/sparse-core/examples/vector.rs
+++ b/sparse-core/examples/vector.rs
@@ -2,6 +2,7 @@
 
 use sparse_core::local::indexable_space::LocalIndexableVectorSpace;
 use sparse_traits::Element;
+use sparse_traits::NormedSpace;
 use sparse_traits::IndexableVector;
 use sparse_traits::LinearSpace;
 use sparse_traits::Norm2;
@@ -16,7 +17,5 @@ fn main() {
     println!("The dimension of the vector is {}", n);
     println!("The norm of the vector is {}", vec.view().norm_2());
 
-    let mut norm: f64 = 0.0;
-    space.norm(vec.view(), &mut norm).unwrap();
-    println!("The norm of the vector is {}", norm);
+    println!("The norm of the vector is {}", space.norm(vec.view()));
 }

--- a/sparse-core/examples/vector.rs
+++ b/sparse-core/examples/vector.rs
@@ -15,4 +15,8 @@ fn main() {
     let n = vec.view().len();
     println!("The dimension of the vector is {}", n);
     println!("The norm of the vector is {}", vec.view().norm_2());
+
+    let mut norm: f64 = 0.0;
+    space.norm(vec.view(), &mut norm).unwrap();
+    println!("The norm of the vector is {}", norm);
 }

--- a/sparse-core/examples/vector.rs
+++ b/sparse-core/examples/vector.rs
@@ -1,0 +1,18 @@
+//! Example file for creating vectors.
+
+use sparse_core::local::indexable_space::LocalIndexableVectorSpace;
+use sparse_traits::Element;
+use sparse_traits::IndexableVector;
+use sparse_traits::LinearSpace;
+use sparse_traits::Norm2;
+
+fn main() {
+    let space = LocalIndexableVectorSpace::<f64>::new(10);
+    let mut vec = space.create_element();
+
+    *vec.view_mut().get_mut(0).unwrap() = 2.0;
+
+    let n = vec.view().len();
+    println!("The dimension of the vector is {}", n);
+    println!("The norm of the vector is {}", vec.view().norm_2());
+}

--- a/sparse-core/examples/vector.rs
+++ b/sparse-core/examples/vector.rs
@@ -3,9 +3,9 @@
 use sparse_core::local::indexable_space::LocalIndexableVectorSpace;
 use sparse_traits::Element;
 use sparse_traits::NormedSpace;
-use sparse_traits::IndexableVector;
+use sparse_traits::linalg::IndexableVector;
 use sparse_traits::LinearSpace;
-use sparse_traits::Norm2;
+use sparse_traits::linalg::Norm2;
 
 fn main() {
     let space = LocalIndexableVectorSpace::<f64>::new(10);
@@ -17,5 +17,5 @@ fn main() {
     println!("The dimension of the vector is {}", n);
     println!("The norm of the vector is {}", vec.view().norm_2());
 
-    println!("The norm of the vector is {}", space.norm(vec.view()));
+    println!("The norm of the vector is {}", space.norm(&vec.view()));
 }

--- a/sparse-core/src/distributed.rs
+++ b/sparse-core/src/distributed.rs
@@ -1,1 +1,4 @@
-pub mod index_set;
+pub mod index_layout;
+pub mod indexable_vector;
+
+pub use indexable_vector::*;

--- a/sparse-core/src/distributed.rs
+++ b/sparse-core/src/distributed.rs
@@ -1,4 +1,5 @@
 pub mod index_layout;
+pub mod indexable_space;
 pub mod indexable_vector;
 
 pub use indexable_vector::*;

--- a/sparse-core/src/distributed/indexable_space.rs
+++ b/sparse-core/src/distributed/indexable_space.rs
@@ -1,0 +1,108 @@
+//! An indexable vector space has elements that can be indexed as n-dimensional vectors.
+
+use mpi::traits::*;
+use std::marker::PhantomData;
+
+use super::index_layout::DistributedIndexLayout;
+use super::indexable_vector::DistributedIndexableVector;
+use sparse_traits::types::{IndexType, Scalar};
+use sparse_traits::{Element, IndexLayout, IndexableVectorSpace, InnerProductSpace};
+use sparse_traits::{Inner, Norm2};
+
+pub struct DistributedIndexableVectorSpace<'comm, T: Scalar + Equivalence, C: Communicator> {
+    index_layout: &'comm DistributedIndexLayout<'comm, C>,
+    _phantom: PhantomData<T>,
+}
+
+impl<'comm, T: Scalar + Equivalence, C: Communicator> DistributedIndexableVectorSpace<'comm, T, C> {
+    pub fn new(index_layout: &'comm DistributedIndexLayout<'comm, C>) -> Self {
+        DistributedIndexableVectorSpace {
+            index_layout,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub struct DistributedIndexableVectorSpaceElement<'comm, T: Scalar + Equivalence, C: Communicator> {
+    space: &'comm DistributedIndexableVectorSpace<'comm, T, C>,
+    data: super::indexable_vector::DistributedIndexableVector<'comm, T, C>,
+}
+
+impl<'comm, T: Scalar + Equivalence, C: Communicator> Element
+    for DistributedIndexableVectorSpaceElement<'comm, T, C> where T::Real: Equivalence
+{
+    type Space = DistributedIndexableVectorSpace<'comm, T, C>;
+    type View<'b> = &'b super::indexable_vector::DistributedIndexableVector<'comm, T, C> where Self: 'b;
+    type ViewMut<'b> = &'b mut super::indexable_vector::DistributedIndexableVector<'comm, T, C> where Self: 'b;
+
+    fn space(&self) -> &Self::Space {
+        self.space
+    }
+
+    fn view<'b>(&'b self) -> Self::View<'b> {
+        &self.data
+    }
+
+    fn view_mut<'b>(&'b mut self) -> Self::ViewMut<'b> {
+        &mut self.data
+    }
+}
+
+impl<'comm,'b: 'comm, T: Scalar + Equivalence, C: Communicator> sparse_traits::LinearSpace
+    for DistributedIndexableVectorSpace<'comm, T, C>
+where
+    T::Real: Equivalence,
+{
+    type F = T;
+    type E<'c> = DistributedIndexableVectorSpaceElement<'comm, T, C> where Self: 'c;
+
+    fn create_element(&'b self) -> Self::E<'b>
+    {
+        DistributedIndexableVectorSpaceElement {
+            space: & self,
+            data: DistributedIndexableVector::<'comm, T, C>::new(&self.index_layout),
+        }
+    }
+
+    fn norm<'c>(
+        &'c self,
+        x: sparse_traits::ElementView<'c, 'c, Self>,
+        res: &mut <Self::F as Scalar>::Real,
+    ) -> sparse_traits::Result<()>
+    {
+        *res = x.norm_2();
+        Ok(())
+    }
+}
+
+impl<'a, T: Scalar + Equivalence, C: Communicator> IndexableVectorSpace
+    for DistributedIndexableVectorSpace<'a, T, C>
+where
+    T::Real: Equivalence,
+{
+    type Ind = DistributedIndexLayout<'a, C>;
+    fn dimension(&self) -> IndexType {
+        self.index_layout().number_of_global_indices()
+    }
+
+    fn index_layout(&self) -> &Self::Ind {
+        &self.index_layout
+    }
+}
+
+impl<'a, T: Scalar + Equivalence, C: Communicator> InnerProductSpace
+    for DistributedIndexableVectorSpace<'a, T, C>
+where
+    T::Real: Equivalence,
+{
+    fn inner<'b>(
+        &self,
+        x: sparse_traits::ElementView<'b, 'b, Self>,
+        other: sparse_traits::ElementView<'b, 'b, Self>,
+    ) -> sparse_traits::Result<Self::F>
+    where
+        Self: 'b,
+    {
+        x.inner(other)
+    }
+}

--- a/sparse-core/src/distributed/indexable_space.rs
+++ b/sparse-core/src/distributed/indexable_space.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use super::index_layout::DistributedIndexLayout;
 use super::indexable_vector::DistributedIndexableVector;
 use sparse_traits::types::{IndexType, Scalar};
+use sparse_traits::Inner;
 use sparse_traits::{Element, IndexLayout, IndexableVectorSpace, InnerProductSpace};
-use sparse_traits::{Inner, Norm2};
 
 pub struct DistributedIndexableVectorSpace<'comm, T: Scalar + Equivalence, C: Communicator> {
     index_layout: &'comm DistributedIndexLayout<'comm, C>,
@@ -23,13 +23,20 @@ impl<'comm, T: Scalar + Equivalence, C: Communicator> DistributedIndexableVector
     }
 }
 
-pub struct DistributedIndexableVectorSpaceElement<'space, 'comm, T: Scalar + Equivalence, C: Communicator> {
+pub struct DistributedIndexableVectorSpaceElement<
+    'space,
+    'comm,
+    T: Scalar + Equivalence,
+    C: Communicator,
+> {
     space: &'space DistributedIndexableVectorSpace<'comm, T, C>,
     data: super::indexable_vector::DistributedIndexableVector<'comm, T, C>,
 }
 
 impl<'space, 'comm, T: Scalar + Equivalence, C: Communicator> Element
-    for DistributedIndexableVectorSpaceElement<'space, 'comm, T, C> where T::Real: Equivalence
+    for DistributedIndexableVectorSpaceElement<'space, 'comm, T, C>
+where
+    T::Real: Equivalence,
 {
     type Space = DistributedIndexableVectorSpace<'comm, T, C>;
     type View<'b> = &'b super::indexable_vector::DistributedIndexableVector<'comm, T, C> where Self: 'b;
@@ -56,22 +63,11 @@ where
     type F = T;
     type E<'space> = DistributedIndexableVectorSpaceElement<'space, 'comm, T, C> where Self: 'space;
 
-    fn create_element<'space>(&'space self) -> Self::E<'space>
-    {
+    fn create_element<'space>(&'space self) -> Self::E<'space> {
         DistributedIndexableVectorSpaceElement {
             space: &self,
             data: DistributedIndexableVector::<'comm, T, C>::new(&self.index_layout),
         }
-    }
-
-    fn norm<'c>(
-        &'c self,
-        x: sparse_traits::ElementView<'c, 'c, Self>,
-        res: &mut <Self::F as Scalar>::Real,
-    ) -> sparse_traits::Result<()>
-    {
-        *res = x.norm_2();
-        Ok(())
     }
 }
 

--- a/sparse-core/src/distributed/indexable_space.rs
+++ b/sparse-core/src/distributed/indexable_space.rs
@@ -23,13 +23,13 @@ impl<'comm, T: Scalar + Equivalence, C: Communicator> DistributedIndexableVector
     }
 }
 
-pub struct DistributedIndexableVectorSpaceElement<'comm, T: Scalar + Equivalence, C: Communicator> {
-    space: &'comm DistributedIndexableVectorSpace<'comm, T, C>,
+pub struct DistributedIndexableVectorSpaceElement<'space, 'comm, T: Scalar + Equivalence, C: Communicator> {
+    space: &'space DistributedIndexableVectorSpace<'comm, T, C>,
     data: super::indexable_vector::DistributedIndexableVector<'comm, T, C>,
 }
 
-impl<'comm, T: Scalar + Equivalence, C: Communicator> Element
-    for DistributedIndexableVectorSpaceElement<'comm, T, C> where T::Real: Equivalence
+impl<'space, 'comm, T: Scalar + Equivalence, C: Communicator> Element
+    for DistributedIndexableVectorSpaceElement<'space, 'comm, T, C> where T::Real: Equivalence
 {
     type Space = DistributedIndexableVectorSpace<'comm, T, C>;
     type View<'b> = &'b super::indexable_vector::DistributedIndexableVector<'comm, T, C> where Self: 'b;
@@ -48,18 +48,18 @@ impl<'comm, T: Scalar + Equivalence, C: Communicator> Element
     }
 }
 
-impl<'comm,'b: 'comm, T: Scalar + Equivalence, C: Communicator> sparse_traits::LinearSpace
+impl<'comm, T: Scalar + Equivalence, C: Communicator> sparse_traits::LinearSpace
     for DistributedIndexableVectorSpace<'comm, T, C>
 where
     T::Real: Equivalence,
 {
     type F = T;
-    type E<'c> = DistributedIndexableVectorSpaceElement<'comm, T, C> where Self: 'c;
+    type E<'space> = DistributedIndexableVectorSpaceElement<'space, 'comm, T, C> where Self: 'space;
 
-    fn create_element(&'b self) -> Self::E<'b>
+    fn create_element<'space>(&'space self) -> Self::E<'space>
     {
         DistributedIndexableVectorSpaceElement {
-            space: & self,
+            space: &self,
             data: DistributedIndexableVector::<'comm, T, C>::new(&self.index_layout),
         }
     }

--- a/sparse-core/src/distributed/indexable_space.rs
+++ b/sparse-core/src/distributed/indexable_space.rs
@@ -93,8 +93,8 @@ where
 {
     fn inner<'b>(
         &self,
-        x: &sparse_traits::ElementView<'b, 'b, Self>,
-        other: &sparse_traits::ElementView<'b, 'b, Self>,
+        x: &sparse_traits::ElementView<'b, Self>,
+        other: &sparse_traits::ElementView<'b, Self>,
     ) -> sparse_traits::Result<Self::F>
     where
         Self: 'b,

--- a/sparse-core/src/distributed/indexable_space.rs
+++ b/sparse-core/src/distributed/indexable_space.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use super::index_layout::DistributedIndexLayout;
 use super::indexable_vector::DistributedIndexableVector;
 use sparse_traits::types::{IndexType, Scalar};
-use sparse_traits::Inner;
-use sparse_traits::{Element, IndexLayout, IndexableVectorSpace, InnerProductSpace};
+use sparse_traits::linalg::Inner;
+use sparse_traits::{Element, IndexLayout, IndexableSpace, InnerProductSpace};
 
 pub struct DistributedIndexableVectorSpace<'comm, T: Scalar + Equivalence, C: Communicator> {
     index_layout: &'comm DistributedIndexLayout<'comm, C>,
@@ -71,7 +71,7 @@ where
     }
 }
 
-impl<'a, T: Scalar + Equivalence, C: Communicator> IndexableVectorSpace
+impl<'a, T: Scalar + Equivalence, C: Communicator> IndexableSpace
     for DistributedIndexableVectorSpace<'a, T, C>
 where
     T::Real: Equivalence,
@@ -93,8 +93,8 @@ where
 {
     fn inner<'b>(
         &self,
-        x: sparse_traits::ElementView<'b, 'b, Self>,
-        other: sparse_traits::ElementView<'b, 'b, Self>,
+        x: &sparse_traits::ElementView<'b, 'b, Self>,
+        other: &sparse_traits::ElementView<'b, 'b, Self>,
     ) -> sparse_traits::Result<Self::F>
     where
         Self: 'b,

--- a/sparse-core/src/distributed/indexable_vector.rs
+++ b/sparse-core/src/distributed/indexable_vector.rs
@@ -2,12 +2,13 @@
 use crate::local::indexable_vector::{
     LocalIndexableVector, LocalIndexableVectorView, LocalIndexableVectorViewMut,
 };
+use crate::tools::has_unique_some;
 use mpi::traits::*;
 use num::{Float, Zero};
-use sparse_traits::linalg::*;
+use sparse_traits::{linalg::*, IndexLayout};
 use sparse_traits::linalg::{AbsSquareSum, Inner, Norm1, Norm2, NormInf};
 use sparse_traits::types::{Error, Result};
-use sparse_traits::Scalar;
+use sparse_traits::{IndexType, Scalar};
 
 use super::index_layout::DistributedIndexLayout;
 
@@ -29,6 +30,31 @@ impl<'a, T: Scalar + Equivalence, C: Communicator> DistributedIndexableVector<'a
 
     fn local(&self) -> Option<&LocalIndexableVector<'a, T>> {
         self.local.as_ref()
+    }
+
+    pub fn fill_from(&self, other: &Option<LocalIndexableVector<T>>) -> Result<()> {
+        let root: i32;
+
+        if let Some(rank) = has_unique_some(other, self.index_layout().comm()) {
+            root = rank
+        } else {
+            return Err(Error::OperationFailed);
+        }
+
+        if root != 0 {
+            return Err(Error::OperationFailed);
+        }
+
+        // Now broadcast the values
+        
+        if self.index_layout().comm().rank() == root{
+            // Broadcast from rank 0
+        } else {
+            // Broadcast into other ranks
+
+        }
+
+        Ok(())
     }
 }
 
@@ -165,5 +191,3 @@ where
         global_result
     }
 }
-
-

--- a/sparse-core/src/distributed/indexable_vector.rs
+++ b/sparse-core/src/distributed/indexable_vector.rs
@@ -2,10 +2,10 @@
 use mpi::traits::*;
 use num::{Float, Zero};
 use sparse_traits::types::{Error, Result};
-use sparse_traits::IndexableVector;
+use sparse_traits::linalg::IndexableVector;
 use sparse_traits::Scalar;
 use sparse_traits::{IndexLayout, IndexType};
-use sparse_traits::{Inner, Norm1, Norm2, NormInf, SquareSum};
+use sparse_traits::linalg::{Inner, Norm1, Norm2, NormInf, SquareSum};
 
 use super::index_layout::DistributedIndexLayout;
 
@@ -172,82 +172,3 @@ where
         global_result
     }
 }
-
-
-/* impl<T: Scalar> IndexableVector for LocalIndexableVector<'_, T> {
-    type Ind = LocalIndexLayout;
-    type Iter<'b> = std::slice::Iter<'b, T> where Self: 'b;
-
-    type IterMut<'b> = std::slice::IterMut<'b, T> where Self: 'b;
-    type T = T;
-
-    fn get(&self, index: IndexType) -> Option<&Self::T> {
-        self.data.get(index)
-    }
-
-    fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T> {
-        self.data.get_mut(index)
-    }
-
-    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T {
-        self.data.get_unchecked(index)
-    }
-
-    unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T {
-        self.data.get_unchecked_mut(index)
-    }
-
-    fn index_set(&self) -> &Self::Ind {
-        &self.index_layout
-    }
-
-    fn iter(&self) -> Self::Iter<'_> {
-        self.data.as_slice().iter()
-    }
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.data.as_mut_slice().iter_mut()
-    }
-
-    fn len(&self) -> IndexType {
-        self.index_layout.number_of_global_indices()
-    }
-}
-
-
-impl<T: Scalar> SquareSum for LocalIndexableVector<'_, T> {
-    type T = T;
-    fn square_sum(&self) -> <Self::T as Scalar>::Real {
-        self.iter()
-            .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
-                acc + elem.square()
-            })
-    }
-}
-
-impl<T: Scalar> Norm1 for LocalIndexableVector<'_, T> {
-    type T = T;
-    fn norm_1(&self) -> <Self::T as Scalar>::Real {
-        self.iter()
-            .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
-                acc + elem.abs()
-            })
-    }
-}
-
-impl<T: Scalar> Norm2 for LocalIndexableVector<'_, T> {
-    type T = T;
-    fn norm_2(&self) -> <Self::T as Scalar>::Real {
-        <<Self::T as Scalar>::Real as Float>::sqrt(self.square_sum())
-    }
-}
-
-impl<T: Scalar> NormInf for LocalIndexableVector<'_, T> {
-    type T = T;
-    fn norm_inf(&self) -> <Self::T as Scalar>::Real {
-        self.iter().fold(
-            <<Self::T as Scalar>::Real as Float>::neg_infinity(),
-            |acc, &elem| <<Self::T as Scalar>::Real as Float>::max(acc, elem.abs()),
-        )
-    }
-} */

--- a/sparse-core/src/distributed/indexable_vector.rs
+++ b/sparse-core/src/distributed/indexable_vector.rs
@@ -2,13 +2,13 @@
 use crate::local::indexable_vector::{
     LocalIndexableVector, LocalIndexableVectorView, LocalIndexableVectorViewMut,
 };
-use crate::tools::has_unique_some;
+use mpi::datatype::Partition;
 use mpi::traits::*;
 use num::{Float, Zero};
-use sparse_traits::{linalg::*, IndexLayout};
-use sparse_traits::linalg::{AbsSquareSum, Inner, Norm1, Norm2, NormInf};
+use sparse_traits::linalg::*;
+use sparse_traits::linalg::{Inner, Norm1, Norm2, NormInf};
 use sparse_traits::types::{Error, Result};
-use sparse_traits::{IndexType, Scalar};
+use sparse_traits::{linalg::IndexableVectorView, IndexLayout, Scalar};
 
 use super::index_layout::DistributedIndexLayout;
 
@@ -32,26 +32,41 @@ impl<'a, T: Scalar + Equivalence, C: Communicator> DistributedIndexableVector<'a
         self.local.as_ref()
     }
 
-    pub fn fill_from(&self, other: &Option<LocalIndexableVector<T>>) -> Result<()> {
-        let root: i32;
+    pub fn fill_from_root(&mut self, other: &Option<LocalIndexableVector<T>>) -> Result<()> {
+        let comm = self.index_layout().comm().duplicate();
+        let counts = self.index_layout().counts().as_slice();
+        let displacements = self.index_layout().displacements().as_slice();
+        let global_dim = self.index_layout().number_of_global_indices();
+        let mut recvbuf = vec![T::zero(); self.index_layout().number_of_local_indices()];
 
-        if let Some(rank) = has_unique_some(other, self.index_layout().comm()) {
-            root = rank
+        let root_process = comm.process_at_rank(0);
+        if comm.rank() == 0 {
+            assert!(other.is_some(), "`other` has a `none` value.");
+
+            let local_vector = other.as_ref().unwrap();
+
+            let local_dim = local_vector.index_layout().number_of_global_indices();
+
+            assert_eq!(
+                local_dim, global_dim,
+                "Dimension of local vector {} does not match dimension of distributed vector {}",
+                local_dim, global_dim
+            );
+
+            let view = local_vector.view().unwrap();
+            let data = view.data().as_ref();
+            let partition = Partition::new(data, counts, displacements);
+
+            root_process.scatter_varcount_into_root(&partition, &mut recvbuf);
+
         } else {
-            return Err(Error::OperationFailed);
+            assert!(other.is_none(), "`other` has a `Some` value.");
+            root_process.scatter_varcount_into(&mut recvbuf);
+
         }
 
-        if root != 0 {
-            return Err(Error::OperationFailed);
-        }
-
-        // Now broadcast the values
-        
-        if self.index_layout().comm().rank() == root{
-            // Broadcast from rank 0
-        } else {
-            // Broadcast into other ranks
-
+        if let Some(mut view) = self.view_mut() {
+            view.data_mut().clone_from_slice(&recvbuf);
         }
 
         Ok(())

--- a/sparse-core/src/distributed/indexable_vector.rs
+++ b/sparse-core/src/distributed/indexable_vector.rs
@@ -1,0 +1,253 @@
+//! An Indexable Vector is a container whose elements can be 1d indexed.
+use mpi::traits::*;
+use num::{Float, Zero};
+use sparse_traits::types::{Error, Result};
+use sparse_traits::IndexableVector;
+use sparse_traits::Scalar;
+use sparse_traits::{IndexLayout, IndexType};
+use sparse_traits::{Inner, Norm1, Norm2, NormInf, SquareSum};
+
+use super::index_layout::DistributedIndexLayout;
+
+pub struct DistributedIndexableVector<'a, T: Scalar + Equivalence, C: Communicator> {
+    data: Vec<T>,
+    index_layout: &'a DistributedIndexLayout<'a, C>,
+}
+
+impl<'a, T: Scalar + Equivalence, C: Communicator> DistributedIndexableVector<'a, T, C> {
+    pub fn new(index_layout: &'a DistributedIndexLayout<'a, C>) -> Self {
+        DistributedIndexableVector {
+            data: vec![T::zero(); index_layout.number_of_local_indices()],
+            index_layout,
+        }
+    }
+}
+
+impl<'a, T: Scalar + Equivalence, C: Communicator> IndexableVector
+    for DistributedIndexableVector<'a, T, C>
+{
+    type T = T;
+    type Ind = DistributedIndexLayout<'a, C>;
+    type Iter<'b> = std::slice::Iter<'b, T> where Self: 'b;
+
+    type IterMut<'b> = std::slice::IterMut<'b, T> where Self: 'b;
+    fn get(&self, index: IndexType) -> Option<&Self::T> {
+        self.data.get(index)
+    }
+    fn len(&self) -> IndexType {
+        self.data.len()
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.data.iter()
+    }
+
+    fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T> {
+        self.data.get_mut(index)
+    }
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.data.iter_mut()
+    }
+
+    fn index_layout(&self) -> &Self::Ind {
+        self.index_layout
+    }
+
+    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T {
+        self.data.get_unchecked(index)
+    }
+
+    unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T {
+        self.data.get_unchecked_mut(index)
+    }
+}
+
+impl<T: Scalar + Equivalence, C: Communicator> Inner for DistributedIndexableVector<'_, T, C> {
+    type T = T;
+    fn inner(&self, other: &Self) -> Result<Self::T> {
+        if self.len() != other.len() {
+            return Err(Error::OperationFailed);
+        }
+
+        let comm = self.index_layout.comm();
+
+        let local_result = self
+            .iter()
+            .zip(other.iter())
+            .fold(<Self::T as Zero>::zero(), |acc, (&first, &second)| {
+                acc + first * second.conj()
+            });
+
+        let mut global_result = T::zero();
+        comm.all_reduce_into(
+            &local_result,
+            &mut global_result,
+            mpi::collective::SystemOperation::sum(),
+        );
+        Ok(global_result)
+    }
+}
+
+impl<T: Scalar + Equivalence, C: Communicator> SquareSum for DistributedIndexableVector<'_, T, C>
+where
+    T::Real: Equivalence,
+{
+    type T = T;
+    fn square_sum(&self) -> <Self::T as Scalar>::Real {
+        let comm = self.index_layout.comm();
+
+        let local_result =
+            self.iter()
+                .fold(<<Self::T as Scalar>::Real as Zero>::zero(), |acc, &elem| {
+                    acc + elem.square()
+                });
+
+        let mut global_result = <<Self::T as Scalar>::Real as Zero>::zero();
+        comm.all_reduce_into(
+            &local_result,
+            &mut global_result,
+            mpi::collective::SystemOperation::sum(),
+        );
+        global_result
+    }
+}
+
+
+impl<T: Scalar + Equivalence, C: Communicator> Norm1 for DistributedIndexableVector<'_, T, C>
+where
+    T::Real: Equivalence,
+{
+    type T = T;
+    fn norm_1(&self) -> <Self::T as Scalar>::Real {
+        let comm = self.index_layout.comm();
+
+        let local_result =
+            self.iter()
+                .fold(<<Self::T as Scalar>::Real as Zero>::zero(), |acc, &elem| {
+                    acc + elem.abs()
+                });
+
+        let mut global_result = <<Self::T as Scalar>::Real as Zero>::zero();
+        comm.all_reduce_into(
+            &local_result,
+            &mut global_result,
+            mpi::collective::SystemOperation::sum(),
+        );
+        global_result
+    }
+}
+
+
+impl<T: Scalar + Equivalence, C: Communicator> Norm2 for DistributedIndexableVector<'_, T, C>
+where
+    T::Real: Equivalence,
+{
+    type T = T;
+    fn norm_2(&self) -> <Self::T as Scalar>::Real {
+        Float::sqrt(self.square_sum())
+    }
+}
+
+impl<T: Scalar + Equivalence, C: Communicator> NormInf for DistributedIndexableVector<'_, T, C>
+where
+    T::Real: Equivalence,
+{
+    type T = T;
+    fn norm_inf(&self) -> <Self::T as Scalar>::Real {
+        let comm = self.index_layout.comm();
+
+        let local_result =
+        self.iter().fold(
+            <<Self::T as Scalar>::Real as Float>::neg_infinity(),
+            |acc, &elem| <<Self::T as Scalar>::Real as Float>::max(acc, elem.abs()),
+        );
+
+        let mut global_result = <<Self::T as Scalar>::Real as Zero>::zero();
+        comm.all_reduce_into(
+            &local_result,
+            &mut global_result,
+            mpi::collective::SystemOperation::max(),
+        );
+        global_result
+    }
+}
+
+
+/* impl<T: Scalar> IndexableVector for LocalIndexableVector<'_, T> {
+    type Ind = LocalIndexLayout;
+    type Iter<'b> = std::slice::Iter<'b, T> where Self: 'b;
+
+    type IterMut<'b> = std::slice::IterMut<'b, T> where Self: 'b;
+    type T = T;
+
+    fn get(&self, index: IndexType) -> Option<&Self::T> {
+        self.data.get(index)
+    }
+
+    fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T> {
+        self.data.get_mut(index)
+    }
+
+    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T {
+        self.data.get_unchecked(index)
+    }
+
+    unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T {
+        self.data.get_unchecked_mut(index)
+    }
+
+    fn index_set(&self) -> &Self::Ind {
+        &self.index_layout
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.data.as_slice().iter()
+    }
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.data.as_mut_slice().iter_mut()
+    }
+
+    fn len(&self) -> IndexType {
+        self.index_layout.number_of_global_indices()
+    }
+}
+
+
+impl<T: Scalar> SquareSum for LocalIndexableVector<'_, T> {
+    type T = T;
+    fn square_sum(&self) -> <Self::T as Scalar>::Real {
+        self.iter()
+            .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
+                acc + elem.square()
+            })
+    }
+}
+
+impl<T: Scalar> Norm1 for LocalIndexableVector<'_, T> {
+    type T = T;
+    fn norm_1(&self) -> <Self::T as Scalar>::Real {
+        self.iter()
+            .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
+                acc + elem.abs()
+            })
+    }
+}
+
+impl<T: Scalar> Norm2 for LocalIndexableVector<'_, T> {
+    type T = T;
+    fn norm_2(&self) -> <Self::T as Scalar>::Real {
+        <<Self::T as Scalar>::Real as Float>::sqrt(self.square_sum())
+    }
+}
+
+impl<T: Scalar> NormInf for LocalIndexableVector<'_, T> {
+    type T = T;
+    fn norm_inf(&self) -> <Self::T as Scalar>::Real {
+        self.iter().fold(
+            <<Self::T as Scalar>::Real as Float>::neg_infinity(),
+            |acc, &elem| <<Self::T as Scalar>::Real as Float>::max(acc, elem.abs()),
+        )
+    }
+} */

--- a/sparse-core/src/distributed/indexable_vector.rs
+++ b/sparse-core/src/distributed/indexable_vector.rs
@@ -6,7 +6,7 @@ use mpi::datatype::Partition;
 use mpi::traits::*;
 use num::{Float, Zero};
 use sparse_traits::linalg::*;
-use sparse_traits::linalg::{Inner, Norm1, Norm2, NormInf};
+use sparse_traits::linalg::{Inner, Norm1, Norm2, NormInfty};
 use sparse_traits::types::{Error, Result};
 use sparse_traits::{linalg::IndexableVectorView, IndexLayout, Scalar};
 
@@ -183,18 +183,18 @@ where
     }
 }
 
-impl<T: Scalar + Equivalence, C: Communicator> NormInf for DistributedIndexableVector<'_, T, C>
+impl<T: Scalar + Equivalence, C: Communicator> NormInfty for DistributedIndexableVector<'_, T, C>
 where
     T::Real: Equivalence,
 {
     type T = T;
-    fn norm_inf(&self) -> <Self::T as Scalar>::Real {
+    fn norm_infty(&self) -> <Self::T as Scalar>::Real {
         let comm = self.index_layout.comm();
 
         let mut local_result = <<Self::T as Scalar>::Real>::zero();
 
         if let Some(local) = self.local() {
-            local_result = local.norm_inf();
+            local_result = local.norm_infty();
         }
 
         let mut global_result = <<Self::T as Scalar>::Real as Zero>::zero();

--- a/sparse-core/src/distributed/indexable_vector.rs
+++ b/sparse-core/src/distributed/indexable_vector.rs
@@ -5,7 +5,7 @@ use sparse_traits::types::{Error, Result};
 use sparse_traits::linalg::IndexableVector;
 use sparse_traits::Scalar;
 use sparse_traits::{IndexLayout, IndexType};
-use sparse_traits::linalg::{Inner, Norm1, Norm2, NormInf, SquareSum};
+use sparse_traits::linalg::{Inner, Norm1, Norm2, NormInf, AbsSquareSum};
 
 use super::index_layout::DistributedIndexLayout;
 
@@ -89,7 +89,7 @@ impl<T: Scalar + Equivalence, C: Communicator> Inner for DistributedIndexableVec
     }
 }
 
-impl<T: Scalar + Equivalence, C: Communicator> SquareSum for DistributedIndexableVector<'_, T, C>
+impl<T: Scalar + Equivalence, C: Communicator> AbsSquareSum for DistributedIndexableVector<'_, T, C>
 where
     T::Real: Equivalence,
 {

--- a/sparse-core/src/index_set.rs
+++ b/sparse-core/src/index_set.rs
@@ -3,4 +3,3 @@ use sparse_traits::{IndexSet, IndexType};
 pub struct SerialIndexSet {
     range: (IndexType, IndexType),
 }
-

--- a/sparse-core/src/lib.rs
+++ b/sparse-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod distributed;
 pub mod local;
+pub mod tools;
 
 #[cfg(test)]
 mod tests {}

--- a/sparse-core/src/lib.rs
+++ b/sparse-core/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod distributed;
-pub mod finite_vector;
 pub mod local;
 
 #[cfg(test)]

--- a/sparse-core/src/local.rs
+++ b/sparse-core/src/local.rs
@@ -1,1 +1,3 @@
 pub mod index_set;
+pub mod indexable_space;
+pub mod indexable_vector;

--- a/sparse-core/src/local.rs
+++ b/sparse-core/src/local.rs
@@ -1,3 +1,3 @@
-pub mod index_set;
+pub mod index_layout;
 pub mod indexable_space;
 pub mod indexable_vector;

--- a/sparse-core/src/local/index_layout.rs
+++ b/sparse-core/src/local/index_layout.rs
@@ -1,11 +1,11 @@
-use sparse_traits::{IndexSet, IndexType};
+use sparse_traits::{IndexLayout, IndexType};
 
-pub struct LocalIndexSet {
+pub struct LocalIndexLayout {
     range: Option<(IndexType, IndexType)>,
     number_of_global_indices: IndexType,
 }
 
-impl LocalIndexSet {
+impl LocalIndexLayout {
     pub fn new(range: (IndexType, IndexType)) -> Self {
         Self {
             range: Some(range),
@@ -14,7 +14,7 @@ impl LocalIndexSet {
     }
 }
 
-impl IndexSet for LocalIndexSet {
+impl IndexLayout for LocalIndexLayout {
     fn number_of_local_indices(&self) -> IndexType {
         self.number_of_global_indices()
     }
@@ -33,6 +33,14 @@ impl IndexSet for LocalIndexSet {
             _ => &None,
         }
     }
+
+    fn local2global(&self, index: IndexType) -> Option<IndexType> {
+        if index < self.number_of_local_indices() {
+            Some(index)
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -42,7 +50,7 @@ mod test {
 
     #[test]
     fn test_local_index_set() {
-        let index_set = LocalIndexSet::new((3, 14));
+        let index_set = LocalIndexLayout::new((3, 14));
 
         // Test that the range is correct on rank 0
         assert_eq!(index_set.index_range(0).unwrap(), (3, 14));

--- a/sparse-core/src/local/index_layout.rs
+++ b/sparse-core/src/local/index_layout.rs
@@ -56,7 +56,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_local_index_set() {
+    fn test_local_index_layout() {
         let index_layout = LocalIndexLayout::new((3, 14));
 
         // Test that the range is correct on rank 0
@@ -64,10 +64,6 @@ mod test {
 
         // Test that the number of global indices is correct.
         assert_eq!(index_layout.number_of_global_indices(), 11);
-
-        // Test that the number of local indices is correct.
-
-        assert!(index_layout.index_range(1).is_none());
 
         // Test that map works
         

--- a/sparse-core/src/local/index_layout.rs
+++ b/sparse-core/src/local/index_layout.rs
@@ -7,6 +7,7 @@ pub struct LocalIndexLayout {
 
 impl LocalIndexLayout {
     pub fn new(range: (IndexType, IndexType)) -> Self {
+        assert!(range.1 >= range.0);
         Self {
             range: Some(range),
             number_of_global_indices: range.1 - range.0,
@@ -23,20 +24,22 @@ impl IndexLayout for LocalIndexLayout {
         &self.range
     }
 
+    fn global_range(&self) -> &(IndexType, IndexType) {
+        self.range.as_ref().unwrap()
+    }
+
     fn number_of_global_indices(&self) -> IndexType {
         self.number_of_global_indices
     }
 
     fn index_range(&self, rank: IndexType) -> &Option<(IndexType, IndexType)> {
-        match rank {
-            0 => &self.range,
-            _ => &None,
-        }
+        assert_eq!(rank, 0, "No rank with index {} exists.", rank);
+        &self.range
     }
 
-    fn local2global(&self, index: IndexType) -> Option<IndexType> {
+    fn map(&self, index: IndexType) -> Option<IndexType> {
         if index < self.number_of_local_indices() {
-            Some(index)
+            Some(index + self.range.unwrap().0)
         } else {
             None
         }
@@ -50,16 +53,20 @@ mod test {
 
     #[test]
     fn test_local_index_set() {
-        let index_set = LocalIndexLayout::new((3, 14));
+        let index_layout = LocalIndexLayout::new((3, 14));
 
         // Test that the range is correct on rank 0
-        assert_eq!(index_set.index_range(0).unwrap(), (3, 14));
+        assert_eq!(index_layout.index_range(0).unwrap(), (3, 14));
 
         // Test that the number of global indices is correct.
-        assert_eq!(index_set.number_of_global_indices(), 11);
+        assert_eq!(index_layout.number_of_global_indices(), 11);
 
         // Test that the number of local indices is correct.
 
-        assert!(index_set.index_range(1).is_none());
+        assert!(index_layout.index_range(1).is_none());
+
+        // Test that map works
+        
+        assert_eq!(index_layout.map(2).unwrap(), 5);
     }
 }

--- a/sparse-core/src/local/index_layout.rs
+++ b/sparse-core/src/local/index_layout.rs
@@ -13,6 +13,10 @@ impl LocalIndexLayout {
             number_of_global_indices: range.1 - range.0,
         }
     }
+
+    pub fn is_same(&self, other: &LocalIndexLayout) -> bool {
+        std::ptr::eq(self, other)
+    }
 }
 
 impl IndexLayout for LocalIndexLayout {

--- a/sparse-core/src/local/indexable_space.rs
+++ b/sparse-core/src/local/indexable_space.rs
@@ -47,7 +47,7 @@ impl<'a, T: Scalar> Element for LocalIndexableVectorSpaceElement<'a, T> {
 
 impl<T: Scalar> sparse_traits::LinearSpace for LocalIndexableVectorSpace<T> {
     type F = T;
-    type E<'a> = LocalIndexableVectorSpaceElement<'a, T>;
+    type E<'a> = LocalIndexableVectorSpaceElement<'a, T> where Self: 'a;
 
     fn create_element<'a>(&'a self) -> Self::E<'a> {
         LocalIndexableVectorSpaceElement {
@@ -57,7 +57,7 @@ impl<T: Scalar> sparse_traits::LinearSpace for LocalIndexableVectorSpace<T> {
     }
 
     fn norm<'a>(
-        &self,
+        &'a self,
         x: sparse_traits::ElementView<'a, 'a, Self>,
         res: &mut <Self::F as Scalar>::Real,
     ) -> sparse_traits::Result<()> {
@@ -82,7 +82,7 @@ impl<T: Scalar> InnerProductSpace for LocalIndexableVectorSpace<T> {
         &self,
         x: sparse_traits::ElementView<'a, 'a, Self>,
         other: sparse_traits::ElementView<'a, 'a, Self>,
-    ) -> sparse_traits::Result<Self::F> {
+    ) -> sparse_traits::Result<Self::F> where Self: 'a{
         x.inner(other)
     }
 }

--- a/sparse-core/src/local/indexable_space.rs
+++ b/sparse-core/src/local/indexable_space.rs
@@ -1,0 +1,62 @@
+//! An indexable vector space has elements that can be indexed as n-dimensional vectors.
+
+use std::marker::PhantomData;
+
+use super::index_set::LocalIndexSet;
+use sparse_traits::spaces::IndexableVectorSpace;
+use sparse_traits::types::{IndexType, Scalar};
+use sparse_traits::Element;
+
+pub struct LocalIndexableVectorSpace<T: Scalar> {
+    index_set: LocalIndexSet,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Scalar> LocalIndexableVectorSpace<T> {
+    pub fn new(n: IndexType) -> Self {
+        LocalIndexableVectorSpace {
+            index_set: LocalIndexSet::new((0, n)),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub struct LocalIndexableVectorSpaceElement<'a, T: Scalar> {
+    index_set: &'a LocalIndexSet,
+    space: &'a LocalIndexableVectorSpace<T>,
+    data: super::indexable_vector::LocalIndexableVector<T>,
+}
+
+impl<'a, T: Scalar> Element for LocalIndexableVectorSpaceElement<'a, T> {
+    type Space = LocalIndexableVectorSpace<T>;
+    type View<'b> = &'b super::indexable_vector::LocalIndexableVector<T> where Self: 'b;
+    type ViewMut<'b> = &'b mut super::indexable_vector::LocalIndexableVector<T> where Self: 'b;
+
+    fn space(&self) -> &Self::Space {
+        self.space
+    }
+
+    fn view<'b>(&'b self) -> Self::View<'b> {
+        &self.data
+    }
+
+    fn view_mut<'b>(&'b mut self) -> Self::ViewMut<'b> {
+        &mut self.data
+    }
+}
+
+impl<'a, T: Scalar> sparse_traits::LinearSpace for LocalIndexableVectorSpace<T> {
+    type F = T;
+    type E = LocalIndexableVectorSpaceElement<'a, T>;
+
+    fn create_element(&self) -> Self::E {
+        std::unimplemented!();
+    }
+
+    fn norm(
+        _x: sparse_traits::ElementView<Self>,
+        _res: &mut <Self::F as Scalar>::Real,
+    ) -> sparse_traits::Result<()> {
+        Err(sparse_traits::Error::NotImplemented)
+    }
+}

--- a/sparse-core/src/local/indexable_space.rs
+++ b/sparse-core/src/local/indexable_space.rs
@@ -72,8 +72,8 @@ impl<T: Scalar> IndexableSpace for LocalIndexableVectorSpace<T> {
 impl<T: Scalar> InnerProductSpace for LocalIndexableVectorSpace<T> {
     fn inner<'a>(
         &self,
-        x: &sparse_traits::ElementView<'a, 'a, Self>,
-        other: &sparse_traits::ElementView<'a, 'a, Self>,
+        x: &sparse_traits::ElementView<'a, Self>,
+        other: &sparse_traits::ElementView<'a, Self>,
     ) -> sparse_traits::Result<Self::F> where Self: 'a{
         x.inner(other)
     }
@@ -81,7 +81,7 @@ impl<T: Scalar> InnerProductSpace for LocalIndexableVectorSpace<T> {
 
 
 impl<T: Scalar> NormedSpace for LocalIndexableVectorSpace<T> {
-   fn norm<'a>(&'a self, x: &sparse_traits::ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real {
+   fn norm<'a>(&'a self, x: &sparse_traits::ElementView<'a, Self>) -> <Self::F as Scalar>::Real {
       x.norm_2() 
    } 
 }

--- a/sparse-core/src/local/indexable_space.rs
+++ b/sparse-core/src/local/indexable_space.rs
@@ -5,8 +5,8 @@ use std::marker::PhantomData;
 use super::index_layout::LocalIndexLayout;
 use super::indexable_vector::LocalIndexableVector;
 use sparse_traits::types::{IndexType, Scalar};
-use sparse_traits::{Element, IndexLayout, IndexableVectorSpace, InnerProductSpace, NormedSpace};
-use sparse_traits::{Inner, Norm2};
+use sparse_traits::{Element, IndexLayout, IndexableSpace, InnerProductSpace, NormedSpace};
+use sparse_traits::linalg::{Inner, Norm2};
 
 pub struct LocalIndexableVectorSpace<T: Scalar> {
     index_layout: LocalIndexLayout,
@@ -58,7 +58,7 @@ impl<T: Scalar> sparse_traits::LinearSpace for LocalIndexableVectorSpace<T> {
 
 }
 
-impl<T: Scalar> IndexableVectorSpace for LocalIndexableVectorSpace<T> {
+impl<T: Scalar> IndexableSpace for LocalIndexableVectorSpace<T> {
     type Ind = LocalIndexLayout;
     fn dimension(&self) -> IndexType {
         self.index_layout().number_of_global_indices()
@@ -72,8 +72,8 @@ impl<T: Scalar> IndexableVectorSpace for LocalIndexableVectorSpace<T> {
 impl<T: Scalar> InnerProductSpace for LocalIndexableVectorSpace<T> {
     fn inner<'a>(
         &self,
-        x: sparse_traits::ElementView<'a, 'a, Self>,
-        other: sparse_traits::ElementView<'a, 'a, Self>,
+        x: &sparse_traits::ElementView<'a, 'a, Self>,
+        other: &sparse_traits::ElementView<'a, 'a, Self>,
     ) -> sparse_traits::Result<Self::F> where Self: 'a{
         x.inner(other)
     }
@@ -81,7 +81,7 @@ impl<T: Scalar> InnerProductSpace for LocalIndexableVectorSpace<T> {
 
 
 impl<T: Scalar> NormedSpace for LocalIndexableVectorSpace<T> {
-   fn norm<'a>(&'a self, x: sparse_traits::ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real {
+   fn norm<'a>(&'a self, x: &sparse_traits::ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real {
       x.norm_2() 
    } 
 }

--- a/sparse-core/src/local/indexable_space.rs
+++ b/sparse-core/src/local/indexable_space.rs
@@ -23,15 +23,14 @@ impl<T: Scalar> LocalIndexableVectorSpace<T> {
 }
 
 pub struct LocalIndexableVectorSpaceElement<'a, T: Scalar> {
-    index_set: &'a LocalIndexSet,
     space: &'a LocalIndexableVectorSpace<T>,
-    data: super::indexable_vector::LocalIndexableVector<T>,
+    data: super::indexable_vector::LocalIndexableVector<'a, T>,
 }
 
 impl<'a, T: Scalar> Element for LocalIndexableVectorSpaceElement<'a, T> {
     type Space = LocalIndexableVectorSpace<T>;
-    type View<'b> = &'b super::indexable_vector::LocalIndexableVector<T> where Self: 'b;
-    type ViewMut<'b> = &'b mut super::indexable_vector::LocalIndexableVector<T> where Self: 'b;
+    type View<'b> = &'b super::indexable_vector::LocalIndexableVector<'b, T> where Self: 'b;
+    type ViewMut<'b> = &'b mut super::indexable_vector::LocalIndexableVector<'a, T> where Self: 'b;
 
     fn space(&self) -> &Self::Space {
         self.space
@@ -52,9 +51,8 @@ impl<T: Scalar> sparse_traits::LinearSpace for LocalIndexableVectorSpace<T> {
 
     fn create_element<'a>(&'a self) -> Self::E<'a> {
         LocalIndexableVectorSpaceElement {
-            index_set: &self.index_set,
             space: &self,
-            data: LocalIndexableVector::new(self.index_set.number_of_global_indices()),
+            data: LocalIndexableVector::new(&self.index_set),
         }
     }
 

--- a/sparse-core/src/local/indexable_space.rs
+++ b/sparse-core/src/local/indexable_space.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use super::index_layout::LocalIndexLayout;
 use super::indexable_vector::LocalIndexableVector;
 use sparse_traits::types::{IndexType, Scalar};
-use sparse_traits::{Element, IndexLayout, IndexableVectorSpace, InnerProductSpace};
+use sparse_traits::{Element, IndexLayout, IndexableVectorSpace, InnerProductSpace, NormedSpace};
 use sparse_traits::{Inner, Norm2};
 
 pub struct LocalIndexableVectorSpace<T: Scalar> {
@@ -56,14 +56,6 @@ impl<T: Scalar> sparse_traits::LinearSpace for LocalIndexableVectorSpace<T> {
         }
     }
 
-    fn norm<'a>(
-        &'a self,
-        x: sparse_traits::ElementView<'a, 'a, Self>,
-        res: &mut <Self::F as Scalar>::Real,
-    ) -> sparse_traits::Result<()> {
-        *res = x.norm_2();
-        Ok(())
-    }
 }
 
 impl<T: Scalar> IndexableVectorSpace for LocalIndexableVectorSpace<T> {
@@ -85,4 +77,11 @@ impl<T: Scalar> InnerProductSpace for LocalIndexableVectorSpace<T> {
     ) -> sparse_traits::Result<Self::F> where Self: 'a{
         x.inner(other)
     }
+}
+
+
+impl<T: Scalar> NormedSpace for LocalIndexableVectorSpace<T> {
+   fn norm<'a>(&'a self, x: sparse_traits::ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real {
+      x.norm_2() 
+   } 
 }

--- a/sparse-core/src/local/indexable_space.rs
+++ b/sparse-core/src/local/indexable_space.rs
@@ -28,12 +28,12 @@ pub struct LocalIndexableVectorSpaceElement<'a, T: Scalar> {
     data: super::indexable_vector::LocalIndexableVector<T>,
 }
 
-impl<'a, T: Scalar> Element<'a> for LocalIndexableVectorSpaceElement<'a, T> {
+impl<'a, T: Scalar> Element for LocalIndexableVectorSpaceElement<'a, T> {
     type Space = LocalIndexableVectorSpace<T>;
     type View<'b> = &'b super::indexable_vector::LocalIndexableVector<T> where Self: 'b;
     type ViewMut<'b> = &'b mut super::indexable_vector::LocalIndexableVector<T> where Self: 'b;
 
-    fn space(&self) -> &'a Self::Space {
+    fn space(&self) -> &Self::Space {
         self.space
     }
 

--- a/sparse-core/src/local/indexable_vector.rs
+++ b/sparse-core/src/local/indexable_vector.rs
@@ -152,9 +152,9 @@ impl<T: Scalar> Norm2 for LocalIndexableVector<'_, T> {
     }
 }
 
-impl<T: Scalar> NormInf for LocalIndexableVector<'_, T> {
+impl<T: Scalar> NormInfty for LocalIndexableVector<'_, T> {
     type T = T;
-    fn norm_inf(&self) -> <Self::T as Scalar>::Real {
+    fn norm_infty(&self) -> <Self::T as Scalar>::Real {
         self.view().unwrap().iter().fold(
             <<Self::T as Scalar>::Real as Float>::neg_infinity(),
             |acc, &elem| <<Self::T as Scalar>::Real as Float>::max(acc, elem.abs()),
@@ -336,7 +336,7 @@ mod tests {
         *vec.view_mut().unwrap().get_mut(0).unwrap() = val1;
         *vec.view_mut().unwrap().get_mut(1).unwrap() = val2;
 
-        let actual = vec.norm_inf();
+        let actual = vec.norm_infty();
         let expected = val2.abs();
 
         float_eq::assert_float_eq!(actual, expected, ulps_all <= 4);

--- a/sparse-core/src/local/indexable_vector.rs
+++ b/sparse-core/src/local/indexable_vector.rs
@@ -1,10 +1,10 @@
 //! An Indexable Vector is a container whose elements can be 1d indexed.
 use num::{Float, Zero};
 use sparse_traits::types::{Error, Result};
-use sparse_traits::IndexableVector;
+use sparse_traits::linalg::IndexableVector;
 use sparse_traits::Scalar;
 use sparse_traits::{IndexLayout, IndexType};
-use sparse_traits::{Inner, Norm1, Norm2, NormInf, SquareSum};
+use sparse_traits::linalg::{Inner, Norm1, Norm2, NormInf, SquareSum};
 
 use super::index_layout::LocalIndexLayout;
 

--- a/sparse-core/src/local/indexable_vector.rs
+++ b/sparse-core/src/local/indexable_vector.rs
@@ -1,7 +1,7 @@
 //! An Indexable Vector is a container whose elements can be 1d indexed.
 use num::{Float, Zero};
 use sparse_traits::linalg::traits::*;
-use sparse_traits::linalg::IndexableVector;
+use sparse_traits::linalg::*;
 use sparse_traits::types::{Error, Result};
 use sparse_traits::Scalar;
 use sparse_traits::{IndexLayout, IndexType};
@@ -11,6 +11,14 @@ use super::index_layout::LocalIndexLayout;
 pub struct LocalIndexableVector<'a, T: Scalar> {
     data: Vec<T>,
     index_layout: &'a LocalIndexLayout,
+}
+
+pub struct LocalIndexableVectorView<'a, T: Scalar> {
+    data: &'a Vec<T>,
+}
+
+pub struct LocalIndexableVectorViewMut<'a, T: Scalar> {
+    data: &'a mut Vec<T>,
 }
 
 impl<'a, T: Scalar> LocalIndexableVector<'a, T> {
@@ -23,58 +31,81 @@ impl<'a, T: Scalar> LocalIndexableVector<'a, T> {
 }
 
 impl<T: Scalar> IndexableVector for LocalIndexableVector<'_, T> {
-    type Ind = LocalIndexLayout;
-    type Iter<'b> = std::slice::Iter<'b, T> where Self: 'b;
-
-    type IterMut<'b> = std::slice::IterMut<'b, T> where Self: 'b;
     type T = T;
+    type Ind = LocalIndexLayout;
+    type View<'a> = LocalIndexableVectorView<'a, T> where Self: 'a;
+    type ViewMut<'a> = LocalIndexableVectorViewMut<'a, T> where Self: 'a;
 
-    fn get(&self, index: IndexType) -> Option<&Self::T> {
-        self.data.get(index)
+    fn index_layout(&self) -> &Self::Ind {
+        &self.index_layout
     }
+
+    fn view<'a>(&'a self) -> Option<Self::View<'a>> {
+        Some(LocalIndexableVectorView { data: &self.data })
+    }
+
+    fn view_mut<'a>(&'a mut self) -> Option<Self::ViewMut<'a>> {
+        Some(LocalIndexableVectorViewMut {
+            data: &mut self.data,
+        })
+    }
+}
+
+macro_rules! implement_view {
+    ($ViewType:ident) => {
+        impl<T: Scalar> IndexableVectorView for $ViewType<'_, T> {
+            type Iter<'b> = std::slice::Iter<'b, T> where Self: 'b;
+
+            type T = T;
+
+            fn get(&self, index: IndexType) -> Option<&Self::T> {
+                self.data.get(index)
+            }
+
+            unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T {
+                self.data.get_unchecked(index)
+            }
+
+            fn iter(&self) -> Self::Iter<'_> {
+                self.data.as_slice().iter()
+            }
+
+            fn len(&self) -> IndexType {
+                self.data.len()
+            }
+        }
+    };
+}
+implement_view!(LocalIndexableVectorView);
+implement_view!(LocalIndexableVectorViewMut);
+
+impl<T: Scalar> IndexableVectorViewMut for LocalIndexableVectorViewMut<'_, T> {
+    type IterMut<'b> = std::slice::IterMut<'b, T> where Self: 'b;
 
     fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T> {
         self.data.get_mut(index)
-    }
-
-    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T {
-        self.data.get_unchecked(index)
     }
 
     unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T {
         self.data.get_unchecked_mut(index)
     }
 
-    fn index_layout(&self) -> &Self::Ind {
-        &self.index_layout
-    }
-
-    fn iter(&self) -> Self::Iter<'_> {
-        self.data.as_slice().iter()
-    }
-
     fn iter_mut(&mut self) -> Self::IterMut<'_> {
         self.data.as_mut_slice().iter_mut()
-    }
-
-    fn len(&self) -> IndexType {
-        self.index_layout.number_of_global_indices()
-    }
-
-    fn new_from(&self) -> Self {
-        Self::new(&self.index_layout)
     }
 }
 
 impl<T: Scalar> Inner for LocalIndexableVector<'_, T> {
     type T = T;
     fn inner(&self, other: &Self) -> Result<Self::T> {
-        if self.len() != other.len() {
+        let my_view = self.view().unwrap();
+        let other_view = other.view().unwrap();
+        if !self.index_layout().is_same(other.index_layout()) {
             return Err(Error::OperationFailed);
         }
-        let result = self
+        let result = my_view
             .iter()
-            .zip(other.iter())
+            .zip(other_view.iter())
             .fold(<Self::T as Zero>::zero(), |acc, (&first, &second)| {
                 acc + first * second.conj()
             });
@@ -85,7 +116,9 @@ impl<T: Scalar> Inner for LocalIndexableVector<'_, T> {
 impl<T: Scalar> AbsSquareSum for LocalIndexableVector<'_, T> {
     type T = T;
     fn abs_square_sum(&self) -> <Self::T as Scalar>::Real {
-        self.iter()
+        self.view()
+            .unwrap()
+            .iter()
             .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
                 acc + elem.square()
             })
@@ -95,7 +128,9 @@ impl<T: Scalar> AbsSquareSum for LocalIndexableVector<'_, T> {
 impl<T: Scalar> Norm1 for LocalIndexableVector<'_, T> {
     type T = T;
     fn norm_1(&self) -> <Self::T as Scalar>::Real {
-        self.iter()
+        self.view()
+            .unwrap()
+            .iter()
             .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
                 acc + elem.abs()
             })
@@ -112,7 +147,7 @@ impl<T: Scalar> Norm2 for LocalIndexableVector<'_, T> {
 impl<T: Scalar> NormInf for LocalIndexableVector<'_, T> {
     type T = T;
     fn norm_inf(&self) -> <Self::T as Scalar>::Real {
-        self.iter().fold(
+        self.view().unwrap().iter().fold(
             <<Self::T as Scalar>::Real as Float>::neg_infinity(),
             |acc, &elem| <<Self::T as Scalar>::Real as Float>::max(acc, elem.abs()),
         )
@@ -122,10 +157,12 @@ impl<T: Scalar> NormInf for LocalIndexableVector<'_, T> {
 impl<T: Scalar> Swap for LocalIndexableVector<'_, T> {
     type T = T;
     fn swap(&mut self, other: &mut Self) -> sparse_traits::types::Result<()> {
-        if self.len() != other.len() {
-            Err(Error::OperationFailed)
+        if !self.index_layout().is_same(other.index_layout()) {
+            return Err(Error::OperationFailed);
         } else {
-            for (first, second) in self.iter_mut().zip(other.iter_mut()) {
+            let mut my_view = self.view_mut().unwrap();
+            let mut other_view = other.view_mut().unwrap();
+            for (first, second) in my_view.iter_mut().zip(other_view.iter_mut()) {
                 std::mem::swap(first, second);
             }
             Ok(())
@@ -136,10 +173,12 @@ impl<T: Scalar> Swap for LocalIndexableVector<'_, T> {
 impl<T: Scalar> Fill for LocalIndexableVector<'_, T> {
     type T = T;
     fn fill(&mut self, other: &Self) -> sparse_traits::types::Result<()> {
-        if self.len() != other.len() {
-            Err(Error::OperationFailed)
+        if !self.index_layout().is_same(other.index_layout()) {
+            return Err(Error::OperationFailed);
         } else {
-            for (first, second) in self.iter_mut().zip(other.iter()) {
+            let mut my_view = self.view_mut().unwrap();
+            let other_view = other.view().unwrap();
+            for (first, second) in my_view.iter_mut().zip(other_view.iter()) {
                 *first = *second;
             }
             Ok(())
@@ -150,7 +189,7 @@ impl<T: Scalar> Fill for LocalIndexableVector<'_, T> {
 impl<T: Scalar> ScalarMult for LocalIndexableVector<'_, T> {
     type T = T;
     fn scalar_mult(&mut self, scalar: Self::T) {
-        for elem in self.iter_mut() {
+        for elem in self.view_mut().unwrap().iter_mut() {
             *elem *= scalar;
         }
     }
@@ -159,19 +198,21 @@ impl<T: Scalar> ScalarMult for LocalIndexableVector<'_, T> {
 impl<T: Scalar> MultSumInto for LocalIndexableVector<'_, T> {
     type T = T;
     fn mult_sum_into(&mut self, other: &Self, scalar: Self::T) -> sparse_traits::types::Result<()> {
-        if self.len() != other.len() {
+        if !self.index_layout().is_same(other.index_layout()) {
             return Err(Error::OperationFailed);
         }
+        let mut my_view = self.view_mut().unwrap();
+        let other_view = other.view().unwrap();
         if scalar == T::zero() {
             return Ok(());
         }
         if scalar == T::one() {
-            for (first, second) in self.iter_mut().zip(other.iter()) {
+            for (first, second) in my_view.iter_mut().zip(other_view.iter()) {
                 *first += *second;
             }
             return Ok(());
         }
-        for (first, second) in self.iter_mut().zip(other.iter()) {
+        for (first, second) in my_view.iter_mut().zip(other_view.iter()) {
             *first += scalar * *second;
         }
         return Ok(());
@@ -202,11 +243,14 @@ mod tests {
         let mut vec1 = new_vec::<c64>(&index_layout);
         let mut vec2 = new_vec::<c64>(&index_layout);
 
-        *vec1.get_mut(0).unwrap() = c64::new(1.0, 2.0);
-        *vec1.get_mut(1).unwrap() = c64::new(0.5, 1.0);
+        let mut vec1_view = vec1.view_mut().unwrap();
+        let mut vec2_view = vec2.view_mut().unwrap();
 
-        *vec2.get_mut(0).unwrap() = c64::new(2.0, 3.0);
-        *vec2.get_mut(1).unwrap() = c64::new(0.4, 1.5);
+        *vec1_view.get_mut(0).unwrap() = c64::new(1.0, 2.0);
+        *vec1_view.get_mut(1).unwrap() = c64::new(0.5, 1.0);
+
+        *vec2_view.get_mut(0).unwrap() = c64::new(2.0, 3.0);
+        *vec2_view.get_mut(1).unwrap() = c64::new(0.4, 1.5);
 
         let actual = vec1.inner(&vec2).unwrap();
 
@@ -222,11 +266,13 @@ mod tests {
 
         let mut vec = new_vec::<c64>(&index_layout);
 
+        let mut vec_view = vec.view_mut().unwrap();
+
         let val1 = c64::new(1.0, 2.0);
         let val2 = c64::new(1.5, 3.0);
 
-        *vec.get_mut(0).unwrap() = val1;
-        *vec.get_mut(1).unwrap() = val2;
+        *vec_view.get_mut(0).unwrap() = val1;
+        *vec_view.get_mut(1).unwrap() = val2;
 
         let actual = vec.abs_square_sum();
         let expected = val1.abs() * val1.abs() + val2.abs() * val2.abs();
@@ -243,8 +289,8 @@ mod tests {
         let val1 = c64::new(1.0, 2.0);
         let val2 = c64::new(1.5, 3.0);
 
-        *vec.get_mut(0).unwrap() = val1;
-        *vec.get_mut(1).unwrap() = val2;
+        *vec.view_mut().unwrap().get_mut(0).unwrap() = val1;
+        *vec.view_mut().unwrap().get_mut(1).unwrap() = val2;
 
         let actual = vec.norm_1();
         let expected = val1.abs() + val2.abs();
@@ -261,8 +307,8 @@ mod tests {
         let val1 = c64::new(1.0, 2.0);
         let val2 = c64::new(1.5, 3.0);
 
-        *vec.get_mut(0).unwrap() = val1;
-        *vec.get_mut(1).unwrap() = val2;
+        *vec.view_mut().unwrap().get_mut(0).unwrap() = val1;
+        *vec.view_mut().unwrap().get_mut(1).unwrap() = val2;
 
         let actual = vec.norm_2();
         let expected = (val1.abs() * val1.abs() + val2.abs() * val2.abs()).sqrt();
@@ -279,8 +325,8 @@ mod tests {
         let val1 = c64::new(1.0, 2.0);
         let val2 = c64::new(1.5, 3.0);
 
-        *vec.get_mut(0).unwrap() = val1;
-        *vec.get_mut(1).unwrap() = val2;
+        *vec.view_mut().unwrap().get_mut(0).unwrap() = val1;
+        *vec.view_mut().unwrap().get_mut(1).unwrap() = val2;
 
         let actual = vec.norm_inf();
         let expected = val2.abs();
@@ -295,16 +341,19 @@ mod tests {
         let mut vec1 = new_vec::<c64>(&index_layout);
         let mut vec2 = new_vec::<c64>(&index_layout);
 
-        *vec1.get_mut(0).unwrap() = c64::new(1.0, 2.0);
-        *vec1.get_mut(1).unwrap() = c64::new(0.5, 1.0);
+        let mut vec1_view = vec1.view_mut().unwrap();
+        let mut vec2_view = vec2.view_mut().unwrap();
 
-        *vec2.get_mut(0).unwrap() = c64::new(2.0, 3.0);
-        *vec2.get_mut(1).unwrap() = c64::new(0.4, 1.5);
+        *vec1_view.get_mut(0).unwrap() = c64::new(1.0, 2.0);
+        *vec1_view.get_mut(1).unwrap() = c64::new(0.5, 1.0);
+
+        *vec2_view.get_mut(0).unwrap() = c64::new(2.0, 3.0);
+        *vec2_view.get_mut(1).unwrap() = c64::new(0.4, 1.5);
 
         vec1.swap(&mut vec2).unwrap();
 
-        assert_eq!(*vec1.get(0).unwrap(), c64::new(2.0, 3.0));
-        assert_eq!(*vec2.get(1).unwrap(), c64::new(0.5, 1.0));
+        assert_eq!(*vec1.view().unwrap().get(0).unwrap(), c64::new(2.0, 3.0));
+        assert_eq!(*vec2.view().unwrap().get(1).unwrap(), c64::new(0.5, 1.0));
     }
 
     #[test]
@@ -314,46 +363,48 @@ mod tests {
         let mut vec1 = new_vec::<c64>(&index_layout);
         let mut vec2 = new_vec::<c64>(&index_layout);
 
-        *vec1.get_mut(0).unwrap() = c64::new(1.0, 2.0);
-        *vec1.get_mut(1).unwrap() = c64::new(0.5, 1.0);
+        let mut vec1_view = vec1.view_mut().unwrap();
+        let mut vec2_view = vec2.view_mut().unwrap();
 
-        *vec2.get_mut(0).unwrap() = c64::new(2.0, 3.0);
-        *vec2.get_mut(1).unwrap() = c64::new(0.4, 1.5);
+        *vec1_view.get_mut(0).unwrap() = c64::new(1.0, 2.0);
+        *vec1_view.get_mut(1).unwrap() = c64::new(0.5, 1.0);
 
+        *vec2_view.get_mut(0).unwrap() = c64::new(2.0, 3.0);
+        *vec2_view.get_mut(1).unwrap() = c64::new(0.4, 1.5);
         // Test scalar = 0
 
         let _ = vec1.mult_sum_into(&vec2, c64::new(0.0, 0.0));
 
-        assert_eq!(*vec1.get(0).unwrap(), c64::new(1.0, 2.0));
-        assert_eq!(*vec1.get(1).unwrap(), c64::new(0.5, 1.0));
+        assert_eq!(*vec1.view().unwrap().get(0).unwrap(), c64::new(1.0, 2.0));
+        assert_eq!(*vec1.view().unwrap().get(1).unwrap(), c64::new(0.5, 1.0));
 
-        *vec1.get_mut(0).unwrap() = c64::new(1.0, 2.0);
-        *vec1.get_mut(1).unwrap() = c64::new(0.5, 1.0);
+        *vec1.view_mut().unwrap().get_mut(0).unwrap() = c64::new(1.0, 2.0);
+        *vec1.view_mut().unwrap().get_mut(1).unwrap() = c64::new(0.5, 1.0);
 
         // Test scalar = 1
         let _ = vec1.mult_sum_into(&vec2, c64::new(1.0, 0.0));
 
         assert_eq!(
-            *vec1.get(0).unwrap(),
+            *vec1.view().unwrap().get(0).unwrap(),
             c64::new(1.0, 2.0) + c64::new(2.0, 3.0)
         );
         assert_eq!(
-            *vec1.get(1).unwrap(),
+            *vec1.view().unwrap().get(1).unwrap(),
             c64::new(0.5, 1.0) + c64::new(0.4, 1.5)
         );
 
-        *vec1.get_mut(0).unwrap() = c64::new(1.0, 2.0);
-        *vec1.get_mut(1).unwrap() = c64::new(0.5, 1.0);
+        *vec1.view_mut().unwrap().get_mut(0).unwrap() = c64::new(1.0, 2.0);
+        *vec1.view_mut().unwrap().get_mut(1).unwrap() = c64::new(0.5, 1.0);
 
         // Test scalar = 1.3
         let _ = vec1.mult_sum_into(&vec2, c64::new(1.3, 0.0));
 
         assert_eq!(
-            *vec1.get(0).unwrap(),
+            *vec1.view().unwrap().get(0).unwrap(),
             c64::new(1.0, 2.0) + c64::new(1.3, 0.0) * c64::new(2.0, 3.0)
         );
         assert_eq!(
-            *vec1.get(1).unwrap(),
+            *vec1.view().unwrap().get(1).unwrap(),
             c64::new(0.5, 1.0) + c64::new(1.3, 0.0) * c64::new(0.4, 1.5)
         );
     }
@@ -366,17 +417,17 @@ mod tests {
         let val1 = c64::new(1.0, 2.0);
         let val2 = c64::new(1.5, 3.0);
 
-        *vec.get_mut(0).unwrap() = val1;
-        *vec.get_mut(1).unwrap() = val2;
+        *vec.view_mut().unwrap().get_mut(0).unwrap() = val1;
+        *vec.view_mut().unwrap().get_mut(1).unwrap() = val2;
 
         vec.scalar_mult(c64::new(2.1, 3.5));
 
         assert_eq!(
-            *vec.get(0).unwrap(),
+            *vec.view().unwrap().get(0).unwrap(),
             c64::new(2.1, 3.5) * c64::new(1.0, 2.0)
         );
         assert_eq!(
-            *vec.get(1).unwrap(),
+            *vec.view().unwrap().get(1).unwrap(),
             c64::new(2.1, 3.5) * c64::new(1.5, 3.0)
         );
     }

--- a/sparse-core/src/local/indexable_vector.rs
+++ b/sparse-core/src/local/indexable_vector.rs
@@ -3,27 +3,27 @@ use num::{Float, Zero};
 use sparse_traits::types::{Error, Result};
 use sparse_traits::IndexableVector;
 use sparse_traits::Scalar;
-use sparse_traits::{IndexSet, IndexType};
+use sparse_traits::{IndexLayout, IndexType};
 use sparse_traits::{Inner, Norm1, Norm2, NormInf, SquareSum};
 
-use super::index_set::LocalIndexSet;
+use super::index_layout::LocalIndexLayout;
 
 pub struct LocalIndexableVector<'a, T: Scalar> {
     data: Vec<T>,
-    index_set: &'a LocalIndexSet,
+    index_layout: &'a LocalIndexLayout,
 }
 
 impl<'a, T: Scalar> LocalIndexableVector<'a, T> {
-    pub fn new(index_set: &'a LocalIndexSet) -> LocalIndexableVector<'a, T> {
+    pub fn new(index_layout: &'a LocalIndexLayout) -> LocalIndexableVector<'a, T> {
         LocalIndexableVector {
-            data: vec![T::zero(); index_set.number_of_global_indices()],
-            index_set,
+            data: vec![T::zero(); index_layout.number_of_global_indices()],
+            index_layout,
         }
     }
 }
 
 impl<T: Scalar> IndexableVector for LocalIndexableVector<'_, T> {
-    type Ind = LocalIndexSet;
+    type Ind = LocalIndexLayout;
     type Iter<'b> = std::slice::Iter<'b, T> where Self: 'b;
 
     type IterMut<'b> = std::slice::IterMut<'b, T> where Self: 'b;
@@ -45,8 +45,8 @@ impl<T: Scalar> IndexableVector for LocalIndexableVector<'_, T> {
         self.data.get_unchecked_mut(index)
     }
 
-    fn index_set(&self) -> &Self::Ind {
-        &self.index_set
+    fn index_layout(&self) -> &Self::Ind {
+        &self.index_layout
     }
 
     fn iter(&self) -> Self::Iter<'_> {
@@ -58,7 +58,7 @@ impl<T: Scalar> IndexableVector for LocalIndexableVector<'_, T> {
     }
 
     fn len(&self) -> IndexType {
-        self.index_set.number_of_global_indices()
+        self.index_layout.number_of_global_indices()
     }
 }
 

--- a/sparse-core/src/local/indexable_vector.rs
+++ b/sparse-core/src/local/indexable_vector.rs
@@ -1,0 +1,116 @@
+//! An Indexable Vector is a container whose elements can be 1d indexed.
+use num::{Float, Zero};
+use sparse_traits::types::{Error, Result};
+use sparse_traits::IndexableVector;
+use sparse_traits::Scalar;
+use sparse_traits::{IndexSet, IndexType};
+use sparse_traits::{Inner, Norm1, Norm2, NormInf, SquareSum};
+
+use super::index_set::LocalIndexSet;
+
+pub struct LocalIndexableVector<T: Scalar> {
+    data: Vec<T>,
+    index_set: LocalIndexSet,
+}
+
+impl<T: Scalar> LocalIndexableVector<T> {
+    pub fn new(n: IndexType) -> LocalIndexableVector<T> {
+        LocalIndexableVector {
+            data: vec![T::zero(); n],
+            index_set: LocalIndexSet::new((0, n)),
+        }
+    }
+}
+
+impl<T: Scalar> IndexableVector for LocalIndexableVector<T> {
+    type Ind = LocalIndexSet;
+    type Iter<'a> = std::slice::Iter<'a, T>;
+
+    type IterMut<'a> = std::slice::IterMut<'a, T>;
+    type T = T;
+
+    fn get(&self, index: IndexType) -> Option<&Self::T> {
+        self.data.get(index)
+    }
+
+    fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T> {
+        self.data.get_mut(index)
+    }
+
+    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T {
+        self.data.get_unchecked(index)
+    }
+
+    unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T {
+        self.data.get_unchecked_mut(index)
+    }
+
+    fn index_set(&self) -> &Self::Ind {
+        &self.index_set
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.data.as_slice().iter()
+    }
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.data.as_mut_slice().iter_mut()
+    }
+
+    fn len(&self) -> IndexType {
+        self.index_set.number_of_global_indices()
+    }
+}
+
+impl<T: Scalar> Inner for LocalIndexableVector<T> {
+    type T = T;
+    fn inner(&self, other: &Self) -> Result<Self::T> {
+        if self.len() != other.len() {
+            return Err(Error::OperationFailed);
+        }
+        let result = self
+            .iter()
+            .zip(other.iter())
+            .fold(<Self::T as Zero>::zero(), |acc, (&first, &second)| {
+                acc + first * second.conj()
+            });
+        Ok(result)
+    }
+}
+
+impl<T: Scalar> SquareSum for LocalIndexableVector<T> {
+    type T = T;
+    fn square_sum(&self) -> <Self::T as Scalar>::Real {
+        self.iter()
+            .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
+                acc + elem.square()
+            })
+    }
+}
+
+impl<T: Scalar> Norm1 for LocalIndexableVector<T> {
+    type T = T;
+    fn norm_1(&self) -> <Self::T as Scalar>::Real {
+        self.iter()
+            .fold(<<Self::T as Scalar>::Real>::zero(), |acc, &elem| {
+                acc + elem.abs()
+            })
+    }
+}
+
+impl<T: Scalar> Norm2 for LocalIndexableVector<T> {
+    type T = T;
+    fn norm_2(&self) -> <Self::T as Scalar>::Real {
+        <<Self::T as Scalar>::Real as Float>::sqrt(self.square_sum())
+    }
+}
+
+impl<T: Scalar> NormInf for LocalIndexableVector<T> {
+    type T = T;
+    fn norm_inf(&self) -> <Self::T as Scalar>::Real {
+        self.iter().fold(
+            <<Self::T as Scalar>::Real as Float>::neg_infinity(),
+            |acc, &elem| <<Self::T as Scalar>::Real as Float>::max(acc, elem.abs()),
+        )
+    }
+}

--- a/sparse-core/src/local/indexable_vector.rs
+++ b/sparse-core/src/local/indexable_vector.rs
@@ -73,6 +73,10 @@ macro_rules! implement_view {
             fn len(&self) -> IndexType {
                 self.data.len()
             }
+
+            fn data(&self) -> &[Self::T] {
+                self.data.as_slice()
+            }
         }
     };
 }
@@ -92,6 +96,10 @@ impl<T: Scalar> IndexableVectorViewMut for LocalIndexableVectorViewMut<'_, T> {
 
     fn iter_mut(&mut self) -> Self::IterMut<'_> {
         self.data.as_mut_slice().iter_mut()
+    }
+
+    fn data_mut(&mut self) -> &mut [Self::T] {
+        self.data.as_mut_slice()
     }
 }
 

--- a/sparse-core/src/tools.rs
+++ b/sparse-core/src/tools.rs
@@ -1,0 +1,2 @@
+//! Various tools
+

--- a/sparse-core/src/tools.rs
+++ b/sparse-core/src/tools.rs
@@ -1,2 +1,48 @@
 //! Various tools
 
+use mpi::traits::*;
+use sparse_traits::types::IndexType;
+
+/// Check if an Option has a ```Some``` value on exactly one process (typically root).
+///
+/// If true return Some(index), where index is the rank of the ```Some```. Otherwise,
+/// return ```None```.
+pub fn has_unique_some<T, C: Communicator>(param: &Option<T>, comm: &C) -> Option<i32> {
+    let flag: i32 = match param {
+        Some(_) => 1,
+        None => 0,
+    };
+
+    let mut global_result: i32 = 0;
+
+    // Send around the flag. At the end the sum of
+    // all flags should be 1.
+    comm.all_reduce_into(
+        &flag,
+        &mut global_result,
+        mpi::collective::SystemOperation::sum(),
+    );
+
+    if global_result != 1 {
+        return None;
+    }
+
+    // We now know that the param has a value
+    // only on one process. Now let's send around
+    // the rank index to everyone.
+
+    let flag: IndexType = match param {
+        Some(_) => comm.rank() as IndexType,
+        None => 0,
+    };
+
+    global_result = 0;
+
+    comm.all_reduce_into(
+        &flag,
+        &mut global_result,
+        mpi::collective::SystemOperation::sum(),
+    );
+
+    Some(global_result)
+}

--- a/sparse-traits/examples/playground.rs
+++ b/sparse-traits/examples/playground.rs
@@ -32,16 +32,16 @@ impl<'a> View<'a> {
     }
 }
 
-impl<'a> Element<'a> for Vec {
+impl Element for Vec {
     type Space = SimpleSpace;
-    type View<'b> = View<'b> where Self: 'b;
-    type ViewMut<'b> = View<'b> where Self: 'b;
+    type View<'a> = View<'a> where Self: 'a;
+    type ViewMut<'a> = View<'a> where Self: 'a;
 
-    fn view<'b>(&'b self) -> Self::View<'b> {
+    fn view<'a>(&'a self) -> Self::View<'a> {
         View::new()
     }
 
-    fn view_mut<'b>(&'b mut self) -> Self::View<'b> {
+    fn view_mut<'a>(&'a mut self) -> Self::View<'a> {
         View::new()
     }
 }

--- a/sparse-traits/examples/playground.rs
+++ b/sparse-traits/examples/playground.rs
@@ -13,7 +13,7 @@ struct SimpleSpace;
 
 impl LinearSpace for SimpleSpace {
     type F = f64;
-    type E = Vec;
+    type E<'a> = Vec;
 }
 
 struct View<'a> {
@@ -32,16 +32,16 @@ impl<'a> View<'a> {
     }
 }
 
-impl Element for Vec {
+impl<'a> Element<'a> for Vec {
     type Space = SimpleSpace;
-    type View<'a> = View<'a> where Self: 'a;
-    type ViewMut<'a> = View<'a> where Self: 'a;
+    type View<'b> = View<'b> where Self: 'b;
+    type ViewMut<'b> = View<'b> where Self: 'b;
 
-    fn view<'a>(&'a self) -> Self::View<'a> {
+    fn view<'b>(&'b self) -> Self::View<'b> {
         View::new()
     }
 
-    fn view_mut<'a>(&'a mut self) -> Self::View<'a> {
+    fn view_mut<'b>(&'b mut self) -> Self::View<'b> {
         View::new()
     }
 }

--- a/sparse-traits/examples/polynomials.rs
+++ b/sparse-traits/examples/polynomials.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 pub struct PolynomialSpace;
 impl LinearSpace for PolynomialSpace {
     type F = f64;
-    type E = Polynomial;
+    type E<'a> = Polynomial;
 }
 
 #[derive(Debug)]
@@ -34,17 +34,17 @@ pub struct PolynomialViewMut<'a> {
     monomial_coeffs: &'a mut [f64],
 }
 
-impl Element for Polynomial {
+impl<'a> Element<'a> for Polynomial {
     type Space = PolynomialSpace;
-    type View<'a> = PolynomialView<'a> where Self: 'a ;
-    type ViewMut<'a> = PolynomialViewMut<'a> where Self: 'a;
+    type View<'b> = PolynomialView<'b> where Self: 'b ;
+    type ViewMut<'b> = PolynomialViewMut<'b> where Self: 'b;
 
-    fn view<'a>(&'a self) -> Self::View<'a> {
+    fn view<'b>(&'b self) -> Self::View<'b> {
         PolynomialView {
             monomial_coeffs: &self.monomial_coeffs,
         }
     }
-    fn view_mut<'a>(&'a mut self) -> PolynomialViewMut<'a> {
+    fn view_mut<'b>(&'b mut self) -> PolynomialViewMut<'b> {
         PolynomialViewMut {
             monomial_coeffs: &mut self.monomial_coeffs,
         }
@@ -54,7 +54,7 @@ impl Element for Polynomial {
 pub struct PointwiseEvaluatorSpace;
 impl LinearSpace for PointwiseEvaluatorSpace {
     type F = f64;
-    type E = PointwiseEvaluate;
+    type E<'a> = PointwiseEvaluate;
 }
 impl DualSpace for PointwiseEvaluatorSpace {
     type Space = PolynomialSpace;
@@ -74,14 +74,14 @@ impl PointwiseEvaluate {
     }
 }
 
-impl Element for PointwiseEvaluate {
+impl<'a> Element<'a> for PointwiseEvaluate {
     type Space = PointwiseEvaluatorSpace;
-    type View<'a> = &'a PointwiseEvaluate where Self: 'a;
-    type ViewMut<'a> = &'a mut PointwiseEvaluate where Self: 'a;
-    fn view<'a>(&'a self) -> Self::View<'a> {
+    type View<'b> = &'b PointwiseEvaluate where Self: 'b;
+    type ViewMut<'b> = &'b mut PointwiseEvaluate where Self: 'b;
+    fn view<'b>(&'b self) -> Self::View<'b> {
         &self
     }
-    fn view_mut<'a>(&'a mut self) -> Self::ViewMut<'a> {
+    fn view_mut<'b>(&'b mut self) -> Self::ViewMut<'b> {
         self
     }
 }

--- a/sparse-traits/examples/polynomials.rs
+++ b/sparse-traits/examples/polynomials.rs
@@ -34,7 +34,7 @@ pub struct PolynomialViewMut<'a> {
     monomial_coeffs: &'a mut [f64],
 }
 
-impl<'a> Element<'a> for Polynomial {
+impl Element for Polynomial {
     type Space = PolynomialSpace;
     type View<'b> = PolynomialView<'b> where Self: 'b ;
     type ViewMut<'b> = PolynomialViewMut<'b> where Self: 'b;
@@ -74,14 +74,14 @@ impl PointwiseEvaluate {
     }
 }
 
-impl<'a> Element<'a> for PointwiseEvaluate {
+impl Element for PointwiseEvaluate {
     type Space = PointwiseEvaluatorSpace;
-    type View<'b> = &'b PointwiseEvaluate where Self: 'b;
-    type ViewMut<'b> = &'b mut PointwiseEvaluate where Self: 'b;
-    fn view<'b>(&'b self) -> Self::View<'b> {
+    type View<'a> = &'a PointwiseEvaluate where Self: 'a;
+    type ViewMut<'a> = &'a mut PointwiseEvaluate where Self: 'a;
+    fn view<'a>(&'a self) -> Self::View<'a> {
         &self
     }
-    fn view_mut<'b>(&'b mut self) -> Self::ViewMut<'b> {
+    fn view_mut<'a>(&'a mut self) -> Self::ViewMut<'a> {
         self
     }
 }

--- a/sparse-traits/src/index_layout.rs
+++ b/sparse-traits/src/index_layout.rs
@@ -6,6 +6,9 @@ pub trait IndexLayout {
     /// The local index range.
     fn local_range(&self) -> &Option<(IndexType, IndexType)>;
 
+    /// Global range.
+    fn global_range(&self) -> &(IndexType, IndexType);
+
     /// Global number of indices.
     fn number_of_global_indices(&self) -> IndexType;
 
@@ -14,6 +17,10 @@ pub trait IndexLayout {
     /// Index range on a given process.
     fn index_range(&self, rank: IndexType) -> &Option<(IndexType, IndexType)>;
 
-    /// Convert local to global indices.
-    fn local2global(&self, index: IndexType) -> Option<IndexType>;
+    /// Convert continuous (0, n) indices to actual indices.
+    ///
+    /// Assume that the local range is (30, 40). Then this method
+    /// will map (0,10) -> (30, 40).
+    /// It returns ```None``` if ```index``` is out of bounds.
+    fn map(&self, index: IndexType) -> Option<IndexType>;
 }

--- a/sparse-traits/src/index_layout.rs
+++ b/sparse-traits/src/index_layout.rs
@@ -2,7 +2,7 @@
 
 use crate::IndexType;
 
-pub trait IndexSet {
+pub trait IndexLayout {
     /// The local index range.
     fn local_range(&self) -> &Option<(IndexType, IndexType)>;
 
@@ -13,4 +13,7 @@ pub trait IndexSet {
 
     /// Index range on a given process.
     fn index_range(&self, rank: IndexType) -> &Option<(IndexType, IndexType)>;
+
+    /// Convert local to global indices.
+    fn local2global(&self, index: IndexType) -> Option<IndexType>;
 }

--- a/sparse-traits/src/indexable_vector.rs
+++ b/sparse-traits/src/indexable_vector.rs
@@ -1,6 +1,6 @@
 //! An indexable vector is the standard type for n-dimensional containers
 use crate::types::{IndexType, Scalar};
-use crate::IndexSet;
+use crate::IndexLayout;
 
 pub trait IndexableVector {
     type T: Scalar;
@@ -11,7 +11,7 @@ pub trait IndexableVector {
     where
         Self: 'a;
 
-    type Ind: IndexSet;
+    type Ind: IndexLayout;
 
     fn iter(&self) -> Self::Iter<'_>;
 
@@ -26,7 +26,7 @@ pub trait IndexableVector {
 
     fn len(&self) -> IndexType;
 
-    fn index_set(&self) -> &Self::Ind;
+    fn index_layout(&self) -> &Self::Ind;
 }
 
 pub trait Inner {

--- a/sparse-traits/src/indexable_vector.rs
+++ b/sparse-traits/src/indexable_vector.rs
@@ -1,0 +1,55 @@
+//! An indexable vector is the standard type for n-dimensional containers
+use crate::types::{IndexType, Scalar};
+use crate::IndexSet;
+
+pub trait IndexableVector {
+    type T: Scalar;
+    type Iter<'a>: std::iter::Iterator<Item = &'a Self::T>
+    where
+        Self: 'a;
+    type IterMut<'a>: std::iter::Iterator<Item = &'a mut Self::T>
+    where
+        Self: 'a;
+
+    type Ind: IndexSet;
+
+    fn iter(&self) -> Self::Iter<'_>;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_>;
+
+    fn get(&self, index: IndexType) -> Option<&Self::T>;
+
+    fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T>;
+
+    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T;
+    unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T;
+
+    fn len(&self) -> IndexType;
+
+    fn index_set(&self) -> &Self::Ind;
+}
+
+pub trait Inner {
+    type T: Scalar;
+    fn inner(&self, other: &Self) -> crate::types::Result<Self::T>;
+}
+
+pub trait SquareSum {
+    type T: Scalar;
+    fn square_sum(&self) -> <Self::T as Scalar>::Real;
+}
+
+pub trait Norm1 {
+    type T: Scalar;
+    fn norm_1(&self) -> <Self::T as Scalar>::Real;
+}
+
+pub trait Norm2 {
+    type T: Scalar;
+    fn norm_2(&self) -> <Self::T as Scalar>::Real;
+}
+
+pub trait NormInf {
+    type T: Scalar;
+    fn norm_inf(&self) -> <Self::T as Scalar>::Real;
+}

--- a/sparse-traits/src/lib.rs
+++ b/sparse-traits/src/lib.rs
@@ -1,11 +1,13 @@
 //! This is a sandbox to test traits for sparse (and more general) operators.
 
 pub mod index_set;
+pub mod indexable_vector;
 pub mod operator;
 pub mod spaces;
 pub mod types;
 
 pub use index_set::*;
+pub use indexable_vector::*;
 pub use operator::*;
 pub use spaces::*;
 pub use types::*;

--- a/sparse-traits/src/lib.rs
+++ b/sparse-traits/src/lib.rs
@@ -1,12 +1,12 @@
 //! This is a sandbox to test traits for sparse (and more general) operators.
 
-pub mod index_set;
+pub mod index_layout;
 pub mod indexable_vector;
 pub mod operator;
 pub mod spaces;
 pub mod types;
 
-pub use index_set::*;
+pub use index_layout::*;
 pub use indexable_vector::*;
 pub use operator::*;
 pub use spaces::*;

--- a/sparse-traits/src/lib.rs
+++ b/sparse-traits/src/lib.rs
@@ -1,13 +1,12 @@
 //! This is a sandbox to test traits for sparse (and more general) operators.
 
 pub mod index_layout;
-pub mod indexable_vector;
 pub mod operator;
 pub mod spaces;
 pub mod types;
+pub mod linalg;
 
 pub use index_layout::*;
-pub use indexable_vector::*;
 pub use operator::*;
 pub use spaces::*;
 pub use types::*;

--- a/sparse-traits/src/linalg.rs
+++ b/sparse-traits/src/linalg.rs
@@ -2,5 +2,5 @@ pub mod indexable_vector;
 pub mod traits;
 
 
-pub use indexable_vector::IndexableVector;
+pub use indexable_vector::{IndexableVector, IndexableVectorView, IndexableVectorViewMut};
 pub use traits::*;

--- a/sparse-traits/src/linalg.rs
+++ b/sparse-traits/src/linalg.rs
@@ -1,0 +1,6 @@
+pub mod indexable_vector;
+pub mod traits;
+
+
+pub use indexable_vector::IndexableVector;
+pub use traits::*;

--- a/sparse-traits/src/linalg/indexable_vector.rs
+++ b/sparse-traits/src/linalg/indexable_vector.rs
@@ -28,6 +28,8 @@ pub trait IndexableVector {
     fn len(&self) -> IndexType;
 
     fn index_layout(&self) -> &Self::Ind;
-}
 
+    fn new_from(&self) -> Self;
+
+}
 

--- a/sparse-traits/src/linalg/indexable_vector.rs
+++ b/sparse-traits/src/linalg/indexable_vector.rs
@@ -33,6 +33,8 @@ pub trait IndexableVectorView {
 
     fn len(&self) -> IndexType;
 
+    fn data(&self) -> &[Self::T];
+
 }
 
 pub trait IndexableVectorViewMut: IndexableVectorView {
@@ -45,6 +47,8 @@ pub trait IndexableVectorViewMut: IndexableVectorView {
     fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T>;
 
     unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T;
+
+    fn data_mut(&mut self) -> &mut [Self::T];
 
 }
 

--- a/sparse-traits/src/linalg/indexable_vector.rs
+++ b/sparse-traits/src/linalg/indexable_vector.rs
@@ -4,32 +4,47 @@ use crate::types::{IndexType, Scalar};
 use crate::IndexLayout;
 
 pub trait IndexableVector {
+
+    type T: Scalar;
+    type Ind: IndexLayout;
+
+    type View<'a>: IndexableVectorView where Self: 'a;
+    type ViewMut<'a>: IndexableVectorView where Self: 'a;
+
+    fn view<'a>(&'a self) -> Option<Self::View<'a>>;
+    fn view_mut<'a>(&'a mut self) -> Option<Self::ViewMut<'a>>;
+
+    fn index_layout(&self) -> &Self::Ind;
+
+}
+
+
+pub trait IndexableVectorView {
     type T: Scalar;
     type Iter<'a>: std::iter::Iterator<Item = &'a Self::T>
     where
         Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_>;
+
+    fn get(&self, index: IndexType) -> Option<&Self::T>;
+
+    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T;
+
+    fn len(&self) -> IndexType;
+
+}
+
+pub trait IndexableVectorViewMut: IndexableVectorView {
     type IterMut<'a>: std::iter::Iterator<Item = &'a mut Self::T>
     where
         Self: 'a;
 
-    type Ind: IndexLayout;
-
-    fn iter(&self) -> Self::Iter<'_>;
-
     fn iter_mut(&mut self) -> Self::IterMut<'_>;
-
-    fn get(&self, index: IndexType) -> Option<&Self::T>;
 
     fn get_mut(&mut self, index: IndexType) -> Option<&mut Self::T>;
 
-    unsafe fn get_unchecked(&self, index: IndexType) -> &Self::T;
     unsafe fn get_unchecked_mut(&mut self, index: IndexType) -> &mut Self::T;
-
-    fn len(&self) -> IndexType;
-
-    fn index_layout(&self) -> &Self::Ind;
-
-    fn new_from(&self) -> Self;
 
 }
 

--- a/sparse-traits/src/linalg/indexable_vector.rs
+++ b/sparse-traits/src/linalg/indexable_vector.rs
@@ -1,4 +1,5 @@
 //! An indexable vector is the standard type for n-dimensional containers
+
 use crate::types::{IndexType, Scalar};
 use crate::IndexLayout;
 
@@ -29,27 +30,4 @@ pub trait IndexableVector {
     fn index_layout(&self) -> &Self::Ind;
 }
 
-pub trait Inner {
-    type T: Scalar;
-    fn inner(&self, other: &Self) -> crate::types::Result<Self::T>;
-}
 
-pub trait SquareSum {
-    type T: Scalar;
-    fn square_sum(&self) -> <Self::T as Scalar>::Real;
-}
-
-pub trait Norm1 {
-    type T: Scalar;
-    fn norm_1(&self) -> <Self::T as Scalar>::Real;
-}
-
-pub trait Norm2 {
-    type T: Scalar;
-    fn norm_2(&self) -> <Self::T as Scalar>::Real;
-}
-
-pub trait NormInf {
-    type T: Scalar;
-    fn norm_inf(&self) -> <Self::T as Scalar>::Real;
-}

--- a/sparse-traits/src/linalg/traits.rs
+++ b/sparse-traits/src/linalg/traits.rs
@@ -1,26 +1,68 @@
-use crate::types::Scalar;
+//! This module defines typical traits for linear algebra operations.
 
+use crate::{types::Scalar, IndexLayout};
+
+/// Inner product with another object.
 pub trait Inner {
     type T: Scalar;
     fn inner(&self, other: &Self) -> crate::types::Result<Self::T>;
 }
 
-pub trait SquareSum {
+/// Take the sum of the squares of the absolute values of the entries.
+pub trait AbsSquareSum {
     type T: Scalar;
     fn square_sum(&self) -> <Self::T as Scalar>::Real;
 }
 
+/// Return the 1-Norm (Sum of absolute values of the entries).
 pub trait Norm1 {
     type T: Scalar;
     fn norm_1(&self) -> <Self::T as Scalar>::Real;
 }
 
+/// Return the 2-Norm (Sqrt of the sum of squares).
 pub trait Norm2 {
     type T: Scalar;
     fn norm_2(&self) -> <Self::T as Scalar>::Real;
 }
 
+/// Return the supremum norm (largest absolute value of the entries).
 pub trait NormInf {
     type T: Scalar;
     fn norm_inf(&self) -> <Self::T as Scalar>::Real;
+}
+
+/// Swap entries with another vector.
+pub trait Swap {
+    type T: Scalar;
+    fn swap(&mut self, other: &mut Self) -> crate::types::Result<()>;
+}
+
+/// Fill vector by copying from another vector.
+pub trait Fill {
+    type T: Scalar;
+    fn fill(&mut self, other: &Self) -> crate::types::Result<()>;
+}
+
+/// Multiply entries with a scalar.
+pub trait ScalarMult {
+    type T: Scalar;
+    fn scalar_mult(&mut self, scalar: Self::T);
+}
+
+/// Compute self -> alpha * other + self.
+pub trait Axpy {
+    type T: Scalar;
+    fn axpy(&mut self, other: &Self, scalar: Self::T) -> crate::types::Result<()>;
+}
+
+/// Create a new vector and fill with scalar.
+pub trait CreateFrom<'a> {
+    type T: Scalar;
+    type Ind: IndexLayout;
+    fn create_from<'b>(index_layout: &'b Self::Ind, scalar: Self::T) -> Self
+    where
+        'b: 'a;
+    // We require that the lifetiime 'b of the index layout lives at least as long as Self.
+    // We cannot write 'b: Self and therefore need to introduce the lifetime parameter 'a;
 }

--- a/sparse-traits/src/linalg/traits.rs
+++ b/sparse-traits/src/linalg/traits.rs
@@ -1,6 +1,6 @@
 //! This module defines typical traits for linear algebra operations.
 
-use crate::{types::Scalar, IndexLayout};
+use crate::types::Scalar;
 
 /// Inner product with another object.
 pub trait Inner {
@@ -11,7 +11,7 @@ pub trait Inner {
 /// Take the sum of the squares of the absolute values of the entries.
 pub trait AbsSquareSum {
     type T: Scalar;
-    fn square_sum(&self) -> <Self::T as Scalar>::Real;
+    fn abs_square_sum(&self) -> <Self::T as Scalar>::Real;
 }
 
 /// Return the 1-Norm (Sum of absolute values of the entries).
@@ -51,18 +51,7 @@ pub trait ScalarMult {
 }
 
 /// Compute self -> alpha * other + self.
-pub trait Axpy {
+pub trait MultSumInto {
     type T: Scalar;
-    fn axpy(&mut self, other: &Self, scalar: Self::T) -> crate::types::Result<()>;
-}
-
-/// Create a new vector and fill with scalar.
-pub trait CreateFrom<'a> {
-    type T: Scalar;
-    type Ind: IndexLayout;
-    fn create_from<'b>(index_layout: &'b Self::Ind, scalar: Self::T) -> Self
-    where
-        'b: 'a;
-    // We require that the lifetiime 'b of the index layout lives at least as long as Self.
-    // We cannot write 'b: Self and therefore need to introduce the lifetime parameter 'a;
+    fn mult_sum_into(&mut self, other: &Self, scalar: Self::T) -> crate::types::Result<()>;
 }

--- a/sparse-traits/src/linalg/traits.rs
+++ b/sparse-traits/src/linalg/traits.rs
@@ -1,0 +1,26 @@
+use crate::types::Scalar;
+
+pub trait Inner {
+    type T: Scalar;
+    fn inner(&self, other: &Self) -> crate::types::Result<Self::T>;
+}
+
+pub trait SquareSum {
+    type T: Scalar;
+    fn square_sum(&self) -> <Self::T as Scalar>::Real;
+}
+
+pub trait Norm1 {
+    type T: Scalar;
+    fn norm_1(&self) -> <Self::T as Scalar>::Real;
+}
+
+pub trait Norm2 {
+    type T: Scalar;
+    fn norm_2(&self) -> <Self::T as Scalar>::Real;
+}
+
+pub trait NormInf {
+    type T: Scalar;
+    fn norm_inf(&self) -> <Self::T as Scalar>::Real;
+}

--- a/sparse-traits/src/linalg/traits.rs
+++ b/sparse-traits/src/linalg/traits.rs
@@ -27,9 +27,9 @@ pub trait Norm2 {
 }
 
 /// Return the supremum norm (largest absolute value of the entries).
-pub trait NormInf {
+pub trait NormInfty {
     type T: Scalar;
-    fn norm_inf(&self) -> <Self::T as Scalar>::Real;
+    fn norm_infty(&self) -> <Self::T as Scalar>::Real;
 }
 
 /// Swap entries with another vector.

--- a/sparse-traits/src/operator.rs
+++ b/sparse-traits/src/operator.rs
@@ -50,7 +50,7 @@ mod tests {
     struct SimpleSpace;
     impl LinearSpace for SimpleSpace {
         type F = f64;
-        type E = SimpleVector;
+        type E<'a> = SimpleVector;
     }
 
     #[derive(Debug)]
@@ -69,16 +69,16 @@ mod tests {
         }
     }
 
-    impl Element for SimpleVector {
+    impl<'a> Element<'a> for SimpleVector {
         type Space = SimpleSpace;
-        type View<'a> = View<'a> where Self: 'a;
-        type ViewMut<'a> = View<'a> where Self: 'a;
+        type View<'b> = View<'b> where Self: 'b;
+        type ViewMut<'b> = View<'b> where Self: 'b;
 
-        fn view<'a>(&'a self) -> Self::View<'a> {
+        fn view<'b>(&'b self) -> Self::View<'b> {
             View::new()
         }
 
-        fn view_mut<'a>(&'a mut self) -> Self::View<'a> {
+        fn view_mut<'b>(&'b mut self) -> Self::View<'b> {
             View::new()
         }
     }

--- a/sparse-traits/src/operator.rs
+++ b/sparse-traits/src/operator.rs
@@ -69,7 +69,7 @@ mod tests {
         }
     }
 
-    impl<'a> Element<'a> for SimpleVector {
+    impl Element for SimpleVector {
         type Space = SimpleSpace;
         type View<'b> = View<'b> where Self: 'b;
         type ViewMut<'b> = View<'b> where Self: 'b;

--- a/sparse-traits/src/spaces.rs
+++ b/sparse-traits/src/spaces.rs
@@ -2,6 +2,7 @@
 
 pub mod dual_space;
 pub mod element;
+pub mod indexable_element;
 pub mod indexable_space;
 pub mod inner_product_space;
 pub mod linear_space;

--- a/sparse-traits/src/spaces.rs
+++ b/sparse-traits/src/spaces.rs
@@ -6,9 +6,11 @@ pub mod indexable_element;
 pub mod indexable_space;
 pub mod inner_product_space;
 pub mod linear_space;
+pub mod normed_space;
 
 pub use dual_space::*;
 pub use element::*;
 pub use indexable_space::*;
 pub use inner_product_space::*;
 pub use linear_space::*;
+pub use normed_space::*;

--- a/sparse-traits/src/spaces/element.rs
+++ b/sparse-traits/src/spaces/element.rs
@@ -22,7 +22,7 @@ pub trait Element {
 }
 
 // The view type associated with elements of linear spaces.
-pub type ElementView<'a, 'b, Space> = <<Space as LinearSpace>::E<'a> as Element>::View<'b>;
+pub type ElementView<'a, Space> = <<Space as LinearSpace>::E<'a> as Element>::View<'a>;
 
 // The mutable view type associated with elements of linear spaces.
-pub type ElementViewMut<'a, 'b, Space> = <<Space as LinearSpace>::E<'a> as Element>::ViewMut<'b>;
+pub type ElementViewMut<'a, Space> = <<Space as LinearSpace>::E<'a> as Element>::ViewMut<'a>;

--- a/sparse-traits/src/spaces/element.rs
+++ b/sparse-traits/src/spaces/element.rs
@@ -1,28 +1,29 @@
 use super::LinearSpace;
 
 /// Elements of linear spaces.
-pub trait Element {
+pub trait Element<'a> {
     /// Item type of the vector.
     type Space: LinearSpace;
-    type View<'a>
+    type View<'b>
     where
-        Self: 'a;
-    type ViewMut<'a>
+        Self: 'b;
+    type ViewMut<'b>
     where
-        Self: 'a;
+        Self: 'b;
 
     /// Return the underlying space.
-    fn space(&self) -> &Self::Space {
+    fn space(&self) -> &'a Self::Space {
         std::unimplemented!();
     }
 
-    fn view<'a>(&'a self) -> Self::View<'a>;
+    fn view<'b>(&'b self) -> Self::View<'b>;
 
-    fn view_mut<'a>(&'a mut self) -> Self::ViewMut<'a>;
+    fn view_mut<'b>(&'b mut self) -> Self::ViewMut<'b>;
 }
 
 // The view type associated with elements of linear spaces.
-pub type ElementView<'a, Space> = <<Space as LinearSpace>::E as Element>::View<'a>;
+pub type ElementView<'a, 'b, Space> = <<Space as LinearSpace>::E<'a> as Element<'a>>::View<'b>;
 
 // The mutable view type associated with elements of linear spaces.
-pub type ElementViewMut<'a, Space> = <<Space as LinearSpace>::E as Element>::ViewMut<'a>;
+pub type ElementViewMut<'a, 'b, Space> =
+    <<Space as LinearSpace>::E<'a> as Element<'a>>::ViewMut<'b>;

--- a/sparse-traits/src/spaces/element.rs
+++ b/sparse-traits/src/spaces/element.rs
@@ -1,7 +1,7 @@
 use super::LinearSpace;
 
 /// Elements of linear spaces.
-pub trait Element<'a> {
+pub trait Element {
     /// Item type of the vector.
     type Space: LinearSpace;
     type View<'b>
@@ -12,7 +12,7 @@ pub trait Element<'a> {
         Self: 'b;
 
     /// Return the underlying space.
-    fn space(&self) -> &'a Self::Space {
+    fn space(&self) -> &Self::Space {
         std::unimplemented!();
     }
 
@@ -22,8 +22,7 @@ pub trait Element<'a> {
 }
 
 // The view type associated with elements of linear spaces.
-pub type ElementView<'a, 'b, Space> = <<Space as LinearSpace>::E<'a> as Element<'a>>::View<'b>;
+pub type ElementView<'a, 'b, Space> = <<Space as LinearSpace>::E<'a> as Element>::View<'b>;
 
 // The mutable view type associated with elements of linear spaces.
-pub type ElementViewMut<'a, 'b, Space> =
-    <<Space as LinearSpace>::E<'a> as Element<'a>>::ViewMut<'b>;
+pub type ElementViewMut<'a, 'b, Space> = <<Space as LinearSpace>::E<'a> as Element>::ViewMut<'b>;

--- a/sparse-traits/src/spaces/indexable_element.rs
+++ b/sparse-traits/src/spaces/indexable_element.rs
@@ -1,6 +1,6 @@
 //! An indexable element has an associated index set.
 use crate::index_set::IndexSet;
 
-pub trait IndexableElement<'a>: super::element::Element<'a> {
+pub trait IndexableElement: super::element::Element {
     fn index_set(&self) -> &dyn IndexSet;
 }

--- a/sparse-traits/src/spaces/indexable_element.rs
+++ b/sparse-traits/src/spaces/indexable_element.rs
@@ -1,0 +1,6 @@
+//! An indexable element has an associated index set.
+use crate::index_set::IndexSet;
+
+pub trait IndexableElement<'a>: super::element::Element<'a> {
+    fn index_set(&self) -> &dyn IndexSet;
+}

--- a/sparse-traits/src/spaces/indexable_element.rs
+++ b/sparse-traits/src/spaces/indexable_element.rs
@@ -1,6 +1,7 @@
 //! An indexable element has an associated index set.
-use crate::index_set::IndexSet;
+use crate::index_layout::IndexLayout;
 
 pub trait IndexableElement: super::element::Element {
-    fn index_set(&self) -> &dyn IndexSet;
+    type Ind: IndexLayout;
+    fn index_layout(&self) -> &Self::Ind;
 }

--- a/sparse-traits/src/spaces/indexable_space.rs
+++ b/sparse-traits/src/spaces/indexable_space.rs
@@ -1,11 +1,12 @@
 use super::LinearSpace;
 use crate::types::IndexType;
-use crate::IndexSet;
+use crate::IndexLayout;
 
 pub trait IndexableVectorSpace: LinearSpace {
+    type Ind: IndexLayout;
     fn dimension(&self) -> IndexType {
-        self.index_set().number_of_global_indices()
+        self.index_layout().number_of_global_indices()
     }
 
-    fn index_set(&self) -> &dyn IndexSet;
+    fn index_layout(&self) -> &Self::Ind;
 }

--- a/sparse-traits/src/spaces/indexable_space.rs
+++ b/sparse-traits/src/spaces/indexable_space.rs
@@ -2,7 +2,7 @@ use super::LinearSpace;
 use crate::types::IndexType;
 use crate::IndexLayout;
 
-pub trait IndexableVectorSpace: LinearSpace {
+pub trait IndexableSpace: LinearSpace {
     type Ind: IndexLayout;
     fn dimension(&self) -> IndexType {
         self.index_layout().number_of_global_indices()

--- a/sparse-traits/src/spaces/inner_product_space.rs
+++ b/sparse-traits/src/spaces/inner_product_space.rs
@@ -3,5 +3,5 @@ use super::LinearSpace;
 use crate::types::Result;
 
 pub trait InnerProductSpace: LinearSpace {
-    fn inner<'a>(&self, x: ElementView<'a, 'a, Self>, other: ElementView<'a, 'a, Self>) -> Result<Self::F> where Self: 'a;
+    fn inner<'a>(&self, x: &ElementView<'a, 'a, Self>, other: &ElementView<'a, 'a, Self>) -> Result<Self::F> where Self: 'a;
 }

--- a/sparse-traits/src/spaces/inner_product_space.rs
+++ b/sparse-traits/src/spaces/inner_product_space.rs
@@ -3,5 +3,5 @@ use super::LinearSpace;
 use crate::types::Result;
 
 pub trait InnerProductSpace: LinearSpace {
-    fn inner<'a>(&self, x: &ElementView<'a, 'a, Self>, other: &ElementView<'a, 'a, Self>) -> Result<Self::F> where Self: 'a;
+    fn inner<'a>(&self, x: &ElementView<'a, Self>, other: &ElementView<'a, Self>) -> Result<Self::F> where Self: 'a;
 }

--- a/sparse-traits/src/spaces/inner_product_space.rs
+++ b/sparse-traits/src/spaces/inner_product_space.rs
@@ -3,5 +3,5 @@ use super::LinearSpace;
 use crate::types::Result;
 
 pub trait InnerProductSpace: LinearSpace {
-    fn inner(&self, x: ElementView<Self>, other: ElementView<Self>) -> Result<Self::F>;
+    fn inner<'a>(&self, x: ElementView<'a, 'a, Self>, other: ElementView<'a, 'a, Self>) -> Result<Self::F> where Self: 'a;
 }

--- a/sparse-traits/src/spaces/linear_space.rs
+++ b/sparse-traits/src/spaces/linear_space.rs
@@ -13,7 +13,7 @@ pub trait LinearSpace {
     type F: Scalar;
 
     /// Type associated with elements of the space.
-    type E<'a>: Element<'a, Space = Self>;
+    type E<'a>: Element<Space = Self>;
 
     /// Create a new vector from the space.
     fn create_element<'a>(&'a self) -> Self::E<'a> {

--- a/sparse-traits/src/spaces/linear_space.rs
+++ b/sparse-traits/src/spaces/linear_space.rs
@@ -13,17 +13,17 @@ pub trait LinearSpace {
     type F: Scalar;
 
     /// Type associated with elements of the space.
-    type E<'a>: Element<Space = Self>;
+    type E<'b>: Element<Space = Self> where Self: 'b;
 
     /// Create a new vector from the space.
-    fn create_element<'a>(&'a self) -> Self::E<'a> {
+    fn create_element<'b>(&'b self) -> Self::E<'b> {
         std::unimplemented!();
     }
 
     /// Norm of a vector.
-    fn norm<'a>(
-        &self,
-        _x: ElementView<'a, 'a, Self>,
+    fn norm<'b>(
+        &'b self,
+        _x: ElementView<'b, 'b, Self>,
         _res: &mut <Self::F as Scalar>::Real,
     ) -> Result<()> {
         Err(Error::NotImplemented)

--- a/sparse-traits/src/spaces/linear_space.rs
+++ b/sparse-traits/src/spaces/linear_space.rs
@@ -21,7 +21,11 @@ pub trait LinearSpace {
     }
 
     /// Norm of a vector.
-    fn norm<'a>(_x: ElementView<'a, 'a, Self>, _res: &mut <Self::F as Scalar>::Real) -> Result<()> {
+    fn norm<'a>(
+        &self,
+        _x: ElementView<'a, 'a, Self>,
+        _res: &mut <Self::F as Scalar>::Real,
+    ) -> Result<()> {
         Err(Error::NotImplemented)
     }
 }

--- a/sparse-traits/src/spaces/linear_space.rs
+++ b/sparse-traits/src/spaces/linear_space.rs
@@ -13,10 +13,10 @@ pub trait LinearSpace {
     type F: Scalar;
 
     /// Type associated with elements of the space.
-    type E: Element<Space = Self>;
+    type E<'a>: Element<'a, Space = Self>;
 
     /// Create a new vector from the space.
-    fn create_element(&self) -> Self::E {
+    fn create_element<'a>(&'a self) -> Self::E<'a> {
         std::unimplemented!();
     }
 

--- a/sparse-traits/src/spaces/linear_space.rs
+++ b/sparse-traits/src/spaces/linear_space.rs
@@ -21,7 +21,7 @@ pub trait LinearSpace {
     }
 
     /// Norm of a vector.
-    fn norm(_x: ElementView<Self>, _res: &mut <Self::F as Scalar>::Real) -> Result<()> {
+    fn norm<'a>(_x: ElementView<'a, 'a, Self>, _res: &mut <Self::F as Scalar>::Real) -> Result<()> {
         Err(Error::NotImplemented)
     }
 }

--- a/sparse-traits/src/spaces/linear_space.rs
+++ b/sparse-traits/src/spaces/linear_space.rs
@@ -1,7 +1,6 @@
 //! Linear spaces and their elements.
 
-use super::{Element, ElementView};
-use crate::types::{Error, Result};
+use super::Element;
 use crate::Scalar;
 
 /// Definition of a linear space
@@ -13,19 +12,12 @@ pub trait LinearSpace {
     type F: Scalar;
 
     /// Type associated with elements of the space.
-    type E<'b>: Element<Space = Self> where Self: 'b;
+    type E<'b>: Element<Space = Self>
+    where
+        Self: 'b;
 
     /// Create a new vector from the space.
     fn create_element<'b>(&'b self) -> Self::E<'b> {
         std::unimplemented!();
-    }
-
-    /// Norm of a vector.
-    fn norm<'b>(
-        &'b self,
-        _x: ElementView<'b, 'b, Self>,
-        _res: &mut <Self::F as Scalar>::Real,
-    ) -> Result<()> {
-        Err(Error::NotImplemented)
     }
 }

--- a/sparse-traits/src/spaces/normed_space.rs
+++ b/sparse-traits/src/spaces/normed_space.rs
@@ -1,0 +1,8 @@
+use super::ElementView;
+use super::LinearSpace;
+use crate::types::Scalar;
+
+pub trait NormedSpace: LinearSpace {
+    /// Norm of a vector.
+    fn norm<'a>(&'a self, x: ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real;
+}

--- a/sparse-traits/src/spaces/normed_space.rs
+++ b/sparse-traits/src/spaces/normed_space.rs
@@ -4,5 +4,5 @@ use crate::types::Scalar;
 
 pub trait NormedSpace: LinearSpace {
     /// Norm of a vector.
-    fn norm<'a>(&'a self, x: &ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real;
+    fn norm<'a>(&'a self, x: &ElementView<'a, Self>) -> <Self::F as Scalar>::Real;
 }

--- a/sparse-traits/src/spaces/normed_space.rs
+++ b/sparse-traits/src/spaces/normed_space.rs
@@ -4,5 +4,5 @@ use crate::types::Scalar;
 
 pub trait NormedSpace: LinearSpace {
     /// Norm of a vector.
-    fn norm<'a>(&'a self, x: ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real;
+    fn norm<'a>(&'a self, x: &ElementView<'a, 'a, Self>) -> <Self::F as Scalar>::Real;
 }


### PR DESCRIPTION
A first version of implementing a concrete vector type within the function space framework.

We have a `LocalndexableVector` type, which provides a basic implementation of a vector (still a lot of methods to be added).

The function space is a `LocalndexableSpace`. This can create vectors of type `LocalIndexableSpaceElement`. These are simply wrappers around `LocalIndexableVector` that additionally contain a back reference to the underlying space and ensure that their lifetime cannot outlive the lifetime of the function space.

Calling `view` on a `LocalIndexableSpaceElement` returns a reference to a `LocalIndexableVector` from which all the usual operations are then accessible.

Under `sparse-core/examples` there is a `vector.rs` example file, which demonstrates that for the user all of this is completely opaque. They create a function space and from that can create vectors and operate on them.

Before merging need

- Some cleaning up
- Implement the corresponding structures for MPI.
- Potentially more discussion on the layout/structure.

